### PR TITLE
Rename Project to DotMP

### DIFF
--- a/.github/workflows/publish_site.yml
+++ b/.github/workflows/publish_site.yml
@@ -1,4 +1,4 @@
-name: Publish OpenMP.NET Site
+name: Publish DotMP Site
 
 on:
   push:

--- a/.github/workflows/test_dotmp.yml
+++ b/.github/workflows/test_dotmp.yml
@@ -1,4 +1,4 @@
-name: Test OpenMP.NET
+name: Test DotMP
 
 on:
   push:
@@ -34,4 +34,4 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Run tests
-      run: dotnet test --verbosity normal OpenMP.NET.Tests/
+      run: dotnet test --verbosity normal DotMP-Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to OpenMP.NET
+# Contributing to DotMP
 
-Contributing to OpenMP.NET is pretty simple.
+Contributing to DotMP is pretty simple.
 As with contributing to any open-source project,
 fork the repository (choose the branch based on the issue you want to work on),
 make local edits, then open a pull request.
@@ -28,7 +28,7 @@ Please adequately document your code, and where it makes sense to explain the fu
 
 ## Optimization Guidelines
 
-This is a clone of OpenMP. OpenMP is heavily optimized. Avoid mutual exclusion where possible, and use locks efficiently where necessary.
+This is a pseudo-implementation of OpenMP. OpenMP is heavily optimized. Avoid mutual exclusion where possible, and use locks efficiently where necessary.
 Don't worry about optimizing to obscurity, but benchmark your code and make sure that you get reasonable scaling.
 
 ## Code of Conduct

--- a/DotMP-Tests/DotMP-Tests.csproj
+++ b/DotMP-Tests/DotMP-Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\DotMP\DotMP.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -4,10 +4,10 @@ using System.Diagnostics;
 using System.Threading;
 using Xunit;
 
-namespace OmpNETTests
+namespace DotMPTests
 {
     /// <summary>
-    /// Tests for the OpenMP.NET library.
+    /// Tests for the DotMP library.
     /// </summary>
     public class ParallelTests
     {
@@ -24,18 +24,18 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.ParallelRegion()'s are actually created.
+        /// Tests to make sure that DotMP.Parallel.ParallelRegion()'s are actually created.
         /// </summary>
         [Fact]
         public void Parallel_should_work()
         {
             var actual = CreateRegion();
 
-            actual.Should().Be((uint)OpenMP.Parallel.GetMaxThreads());
+            actual.Should().Be((uint)DotMP.Parallel.GetMaxThreads());
         }
 
         /// <summary>
-        /// Tests the functionality of OpenMP.Parallel.For().
+        /// Tests the functionality of DotMP.Parallel.For().
         /// </summary>
         [Fact]
         public void Parallelfor_should_work()
@@ -61,7 +61,7 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Schedule.Static produces correct results.
+        /// Tests to make sure that DotMP.Parallel.Schedule.Static produces correct results.
         /// </summary>
         [Fact]
         public void Static_should_produce_correct_results()
@@ -86,28 +86,28 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Schedule.Runtime properly reads values from the environment variable.
+        /// Tests to make sure that DotMP.Parallel.Schedule.Runtime properly reads values from the environment variable.
         /// </summary>
         [Fact]
         public void Schedule_runtime_works()
         {
             Environment.SetEnvironmentVariable("OMP_SCHEDULE", "guided,2");
-            OpenMP.Parallel.ParallelFor(0, 1024, schedule: OpenMP.Parallel.Schedule.Runtime, action: i =>
+            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Parallel.Schedule.Runtime, action: i =>
             {
-                OpenMP.Parallel.GetSchedule().Should().Be(OpenMP.Parallel.Schedule.Guided);
-                OpenMP.Parallel.GetChunkSize().Should().Be(2);
+                DotMP.Parallel.GetSchedule().Should().Be(DotMP.Parallel.Schedule.Guided);
+                DotMP.Parallel.GetChunkSize().Should().Be(2);
             });
 
             Environment.SetEnvironmentVariable("OMP_SCHEDULE", "dynamic,4");
-            OpenMP.Parallel.ParallelFor(0, 1024, schedule: OpenMP.Parallel.Schedule.Runtime, action: i =>
+            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Parallel.Schedule.Runtime, action: i =>
             {
-                OpenMP.Parallel.GetSchedule().Should().Be(OpenMP.Parallel.Schedule.Dynamic);
-                OpenMP.Parallel.GetChunkSize().Should().Be(4);
+                DotMP.Parallel.GetSchedule().Should().Be(DotMP.Parallel.Schedule.Dynamic);
+                DotMP.Parallel.GetChunkSize().Should().Be(4);
             });
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Critical() works.
+        /// Tests to make sure that DotMP.Parallel.Critical() works.
         /// </summary>
         [Fact]
         public void Critical_works()
@@ -117,9 +117,9 @@ namespace OmpNETTests
             int one = critical_ids(false);
             int two = critical_ids(true);
 
-            OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
+            DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                int id = OpenMP.Parallel.Critical(5, () => ++total);
+                int id = DotMP.Parallel.Critical(5, () => ++total);
                 id.Should().Be(3);
             });
 
@@ -129,7 +129,7 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Master() works.
+        /// Tests to make sure that DotMP.Parallel.Master() works.
         /// </summary>
         [Fact]
         public void Master_works()
@@ -137,16 +137,16 @@ namespace OmpNETTests
             uint threads = 1024;
             int total = 0;
 
-            OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
+            DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                OpenMP.Parallel.Master(() => ++total);
+                DotMP.Parallel.Master(() => ++total);
             });
 
             total.Should().Be(1);
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Single() works.
+        /// Tests to make sure that DotMP.Parallel.Single() works.
         /// </summary>
         [Fact]
         public void Single_works()
@@ -154,16 +154,16 @@ namespace OmpNETTests
             uint threads = 1024;
             int total = 0;
 
-            OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
+            DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                OpenMP.Parallel.Single(0, () => ++total);
+                DotMP.Parallel.Single(0, () => ++total);
             });
 
             total.Should().Be(1);
         }
 
         /// <summary>
-        /// Tests to make sure that the OpenMP.Atomic class works.
+        /// Tests to make sure that the DotMP.Atomic class works.
         /// </summary>
         [Fact]
         public void Atomic_works()
@@ -172,10 +172,10 @@ namespace OmpNETTests
             uint total = 0;
             long total2 = 0;
 
-            OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
+            DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                OpenMP.Atomic.Inc(ref total);
-                OpenMP.Atomic.Sub(ref total2, 2);
+                DotMP.Atomic.Inc(ref total);
+                DotMP.Atomic.Sub(ref total2, 2);
             });
 
             total.Should().Be(threads);
@@ -183,7 +183,7 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Ordered() works.
+        /// Tests to make sure that DotMP.Parallel.Ordered() works.
         /// </summary>
         [Fact]
         public void Ordered_works()
@@ -191,10 +191,10 @@ namespace OmpNETTests
             uint threads = 8;
             int[] incrementing = new int[1024];
 
-            OpenMP.Parallel.ParallelFor(0, 1024, schedule: OpenMP.Parallel.Schedule.Static,
+            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Parallel.Schedule.Static,
                                         num_threads: threads, action: i =>
             {
-                OpenMP.Parallel.Ordered(0, () => incrementing[i] = i);
+                DotMP.Parallel.Ordered(0, () => incrementing[i] = i);
             });
 
             for (int i = 0; i < incrementing.Length; i++)
@@ -204,19 +204,19 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.ForReduction<T>() works.
+        /// Tests to make sure that DotMP.Parallel.ForReduction<T>() works.
         /// </summary>
         [Fact]
         public void Reduction_works()
         {
             int total = 0;
 
-            OpenMP.Parallel.ParallelForReduction(0, 1024, OpenMP.Operations.Add, ref total, num_threads: 8, schedule: OpenMP.Parallel.Schedule.Static, action: (ref int total, int i) =>
+            DotMP.Parallel.ParallelForReduction(0, 1024, DotMP.Operations.Add, ref total, num_threads: 8, schedule: DotMP.Parallel.Schedule.Static, action: (ref int total, int i) =>
             {
                 total += i;
             });
 
-            OpenMP.Parallel.ParallelForReduction(0, 1024, OpenMP.Operations.Add, ref total, num_threads: 8, schedule: OpenMP.Parallel.Schedule.Static, action: (ref int total, int i) =>
+            DotMP.Parallel.ParallelForReduction(0, 1024, DotMP.Operations.Add, ref total, num_threads: 8, schedule: DotMP.Parallel.Schedule.Static, action: (ref int total, int i) =>
             {
                 total += i;
             });
@@ -225,90 +225,90 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.SetNumThreads() works.
+        /// Tests to make sure that DotMP.Parallel.SetNumThreads() works.
         /// </summary>
         [Fact]
         public void SetNumThreads_works()
         {
-            OpenMP.Parallel.GetMaxThreads().Should().Be(OpenMP.Parallel.GetNumProcs());
+            DotMP.Parallel.GetMaxThreads().Should().Be(DotMP.Parallel.GetNumProcs());
 
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.ParallelRegion(() =>
             {
-                OpenMP.Parallel.GetNumThreads().Should().Be(OpenMP.Parallel.GetNumProcs());
+                DotMP.Parallel.GetNumThreads().Should().Be(DotMP.Parallel.GetNumProcs());
             });
 
-            OpenMP.Parallel.ParallelRegion(num_threads: 2, action: () =>
+            DotMP.Parallel.ParallelRegion(num_threads: 2, action: () =>
             {
-                OpenMP.Parallel.GetNumThreads().Should().Be(2);
+                DotMP.Parallel.GetNumThreads().Should().Be(2);
             });
 
-            OpenMP.Parallel.SetNumThreads(15);
-            OpenMP.Parallel.GetMaxThreads().Should().Be(15);
+            DotMP.Parallel.SetNumThreads(15);
+            DotMP.Parallel.GetMaxThreads().Should().Be(15);
 
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.ParallelRegion(() =>
             {
-                OpenMP.Parallel.GetNumThreads().Should().Be(15);
+                DotMP.Parallel.GetNumThreads().Should().Be(15);
             });
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.InParallel() works.
+        /// Tests to make sure that DotMP.Parallel.InParallel() works.
         /// </summary>
         [Fact]
         public void InParallel_works()
         {
-            OpenMP.Parallel.InParallel().Should().BeFalse();
+            DotMP.Parallel.InParallel().Should().BeFalse();
 
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.ParallelRegion(() =>
             {
-                OpenMP.Parallel.InParallel().Should().BeTrue();
+                DotMP.Parallel.InParallel().Should().BeTrue();
             });
 
-            OpenMP.Parallel.InParallel().Should().BeFalse();
+            DotMP.Parallel.InParallel().Should().BeFalse();
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.SetDynamic() works.
+        /// Tests to make sure that DotMP.Parallel.SetDynamic() works.
         /// </summary>
         [Fact]
         public void SetDynamic_works()
         {
-            OpenMP.Parallel.SetNumThreads(2);
-            OpenMP.Parallel.GetDynamic().Should().BeFalse();
-            OpenMP.Parallel.SetDynamic();
-            OpenMP.Parallel.GetDynamic().Should().BeTrue();
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.SetNumThreads(2);
+            DotMP.Parallel.GetDynamic().Should().BeFalse();
+            DotMP.Parallel.SetDynamic();
+            DotMP.Parallel.GetDynamic().Should().BeTrue();
+            DotMP.Parallel.ParallelRegion(() =>
             {
-                OpenMP.Parallel.GetNumThreads().Should().Be(OpenMP.Parallel.GetNumProcs());
+                DotMP.Parallel.GetNumThreads().Should().Be(DotMP.Parallel.GetNumProcs());
             });
-            OpenMP.Parallel.GetDynamic().Should().BeTrue();
-            OpenMP.Parallel.SetNumThreads(OpenMP.Parallel.GetNumProcs());
-            OpenMP.Parallel.GetDynamic().Should().BeFalse();
+            DotMP.Parallel.GetDynamic().Should().BeTrue();
+            DotMP.Parallel.SetNumThreads(DotMP.Parallel.GetNumProcs());
+            DotMP.Parallel.GetDynamic().Should().BeFalse();
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.GetWTime() works.
+        /// Tests to make sure that DotMP.Parallel.GetWTime() works.
         /// </summary>
         [Fact]
         public void GetWTime_works()
         {
-            double start = OpenMP.Parallel.GetWTime();
+            double start = DotMP.Parallel.GetWTime();
             Thread.Sleep(1000);
-            double end = OpenMP.Parallel.GetWTime();
+            double end = DotMP.Parallel.GetWTime();
             (end - start).Should().BeGreaterOrEqualTo(1.0);
             (end - start).Should().BeLessThan(1.1);
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.GetNested() and OpenMP.Parallel.SetNested() work.
+        /// Tests to make sure that DotMP.Parallel.GetNested() and DotMP.Parallel.SetNested() work.
         /// </summary>
         [Fact]
         public void GetNested_works()
         {
-            OpenMP.Parallel.GetNested().Should().BeFalse();
+            DotMP.Parallel.GetNested().Should().BeFalse();
             try
             {
-                OpenMP.Parallel.SetNested(true);
+                DotMP.Parallel.SetNested(true);
                 true.Should().BeFalse();
             }
             catch (NotImplementedException e)
@@ -318,57 +318,57 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Tests to make sure that the OpenMP.Locking and OpenMP.Lock classes work.
+        /// Tests to make sure that the DotMP.Locking and DotMP.Lock classes work.
         /// </summary>
         [Fact]
         public void Locks_work()
         {
             uint threads = 16;
-            OpenMP.Lock l = new OpenMP.Lock();
+            DotMP.Lock l = new DotMP.Lock();
 
-            double time = OpenMP.Parallel.GetWTime();
+            double time = DotMP.Parallel.GetWTime();
 
-            OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
+            DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                OpenMP.Locking.Set(l);
+                DotMP.Locking.Set(l);
                 Thread.Sleep(100);
-                OpenMP.Locking.Unset(l);
+                DotMP.Locking.Unset(l);
             });
 
-            double elapsed = OpenMP.Parallel.GetWTime() - time;
+            double elapsed = DotMP.Parallel.GetWTime() - time;
             elapsed.Should().BeGreaterThan(1.6);
 
-            OpenMP.Locking.Test(l).Should().BeTrue();
-            OpenMP.Locking.Test(l).Should().BeFalse();
-            OpenMP.Locking.Test(l).Should().BeFalse();
-            OpenMP.Locking.Unset(l);
-            OpenMP.Locking.Test(l).Should().BeTrue();
-            OpenMP.Locking.Test(l).Should().BeFalse();
-            OpenMP.Locking.Test(l).Should().BeFalse();
-            OpenMP.Locking.Unset(l);
+            DotMP.Locking.Test(l).Should().BeTrue();
+            DotMP.Locking.Test(l).Should().BeFalse();
+            DotMP.Locking.Test(l).Should().BeFalse();
+            DotMP.Locking.Unset(l);
+            DotMP.Locking.Test(l).Should().BeTrue();
+            DotMP.Locking.Test(l).Should().BeFalse();
+            DotMP.Locking.Test(l).Should().BeFalse();
+            DotMP.Locking.Unset(l);
         }
 
         /// <summary>
-        /// Tests to make sure the OpenMP.Shared class works.
+        /// Tests to make sure the DotMP.Shared class works.
         /// </summary>
         [Fact]
         public void Shared_works()
         {
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.ParallelRegion(() =>
             {
-                OpenMP.Shared<int> s = new OpenMP.Shared<int>("s", 6);
+                DotMP.Shared<int> s = new DotMP.Shared<int>("s", 6);
                 s.Get().Should().Be(6);
-                OpenMP.Parallel.Barrier();
-                OpenMP.Parallel.Master(() => s.Set(7));
-                OpenMP.Parallel.Barrier();
+                DotMP.Parallel.Barrier();
+                DotMP.Parallel.Master(() => s.Set(7));
+                DotMP.Parallel.Barrier();
                 s.Get().Should().Be(7);
-                OpenMP.Parallel.Barrier();
+                DotMP.Parallel.Barrier();
                 s.Clear();
             });
         }
 
         /// <summary>
-        /// Tests to make sure that OpenMP.Parallel.Sections() and OpenMP.Parallel.Section() work.
+        /// Tests to make sure that DotMP.Parallel.Sections() and DotMP.Parallel.Section() work.
         /// </summary>
         [Fact]
         public void Sections_works()
@@ -379,21 +379,21 @@ namespace OmpNETTests
             for (int i = 0; i < num_threads; i++)
                 threads_used[i] = false;
 
-            double start = OpenMP.Parallel.GetWTime();
+            double start = DotMP.Parallel.GetWTime();
 
-            OpenMP.Parallel.ParallelSections(num_threads: num_threads, action: () =>
+            DotMP.Parallel.ParallelSections(num_threads: num_threads, action: () =>
             {
                 for (int i = 0; i < num_threads; i++)
                 {
-                    OpenMP.Parallel.Section(() =>
+                    DotMP.Parallel.Section(() =>
                     {
-                        threads_used[OpenMP.Parallel.GetThreadNum()] = true;
+                        threads_used[DotMP.Parallel.GetThreadNum()] = true;
                         Thread.Sleep(100);
                     });
                 }
             });
 
-            double end = OpenMP.Parallel.GetWTime() - start;
+            double end = DotMP.Parallel.GetWTime() - start;
 
             for (int i = 0; i < num_threads; i++)
                 threads_used[i].Should().Be(true);
@@ -402,7 +402,7 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// A sample workload for OpenMP.Parallel.ParallelFor().
+        /// A sample workload for DotMP.Parallel.ParallelFor().
         /// </summary>
         /// <param name="inParallel">Whether or not to enable parallelism.</param>
         /// <returns>Elapsed milliseconds of the test.</returns>
@@ -431,7 +431,7 @@ namespace OmpNETTests
             {
                 if (inParallel)
                 {
-                    OpenMP.Parallel.ParallelFor(0, WORKLOAD, schedule: OpenMP.Parallel.Schedule.Guided,
+                    DotMP.Parallel.ParallelFor(0, WORKLOAD, schedule: DotMP.Parallel.Schedule.Guided,
                         action: j => InnerWorkload(j, a, b, c));
                 }
                 else
@@ -472,7 +472,7 @@ namespace OmpNETTests
         {
             uint threads_spawned = 0;
 
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.ParallelRegion(() =>
             {
                 Interlocked.Add(ref threads_spawned, 1);
             });
@@ -491,9 +491,9 @@ namespace OmpNETTests
         {
             float[] z = new float[x.Length];
 
-            OpenMP.Parallel.ParallelRegion(() =>
+            DotMP.Parallel.ParallelRegion(() =>
             {
-                OpenMP.Parallel.For(0, x.Length, schedule: OpenMP.Parallel.Schedule.Guided, action: i =>
+                DotMP.Parallel.For(0, x.Length, schedule: DotMP.Parallel.Schedule.Guided, action: i =>
                 {
                     z[i] = a * x[i] + y[i];
                 });
@@ -503,7 +503,7 @@ namespace OmpNETTests
         }
 
         /// <summary>
-        /// Same as saxpy_parallelregion_for, but uses OpenMP.Parallel.ParallelFor() instead of OpenMP.Parallel.ParallelRegion() and OpenMP.Parallel.For().
+        /// Same as saxpy_parallelregion_for, but uses DotMP.Parallel.ParallelFor() instead of DotMP.Parallel.ParallelRegion() and DotMP.Parallel.For().
         /// </summary>
         /// <param name="a">Scalar for saxpy.</param>
         /// <param name="x">Vector to multiply by the scalar.</param>
@@ -513,7 +513,7 @@ namespace OmpNETTests
         {
             float[] z = new float[x.Length];
 
-            OpenMP.Parallel.ParallelFor(0, x.Length, schedule: OpenMP.Parallel.Schedule.Guided, action: i =>
+            DotMP.Parallel.ParallelFor(0, x.Length, schedule: DotMP.Parallel.Schedule.Guided, action: i =>
             {
                 z[i] = a * x[i] + y[i];
             });
@@ -536,16 +536,16 @@ namespace OmpNETTests
 
             for (int i = 0; i < 5; i++)
             {
-                OpenMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
+                DotMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
                 {
-                    int id1 = OpenMP.Parallel.Critical(0, () => ++x);
+                    int id1 = DotMP.Parallel.Critical(0, () => ++x);
                     int id2 = -1;
 
-                    OpenMP.Parallel.For(0, 100, schedule: OpenMP.Parallel.Schedule.Static, action: j =>
+                    DotMP.Parallel.For(0, 100, schedule: DotMP.Parallel.Schedule.Static, action: j =>
                     {
                         if (two_regions)
                         {
-                            id2 = OpenMP.Parallel.Critical(1, () => ++y);
+                            id2 = DotMP.Parallel.Critical(1, () => ++y);
                         }
 
                         lock (mylock)

--- a/DotMP/Atomic.cs
+++ b/DotMP/Atomic.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Provides atomic operations for integral types as a wrapper around the Interlocked class.

--- a/DotMP/DotMP.csproj
+++ b/DotMP/DotMP.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp6.0</TargetFramework>
-    <RootNamespace>OpenMP</RootNamespace>
+    <RootNamespace>DotMP</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/DotMP/DotMP.sln
+++ b/DotMP/DotMP.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32602.215
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenMP.NET", "OpenMP.NET.csproj", "{FBB6A87A-06EB-4C00-9CA4-4D42B9E53A54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotMP", "DotMP.csproj", "{FBB6A87A-06EB-4C00-9CA4-4D42B9E53A54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenMP.NET.Tests", "..\OpenMP.NET.Tests\OpenMP.NET.Tests.csproj", "{03183624-736C-4594-9E3B-AE8F03B4B47A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotMP-Tests", "..\DotMP-Tests\DotMP-Tests.csproj", "{03183624-736C-4594-9E3B-AE8F03B4B47A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/DotMP/Exceptions.cs
+++ b/DotMP/Exceptions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Exception thrown if a parallel-only construct is used outside of a parallel region.

--- a/DotMP/ForkedRegion.cs
+++ b/DotMP/ForkedRegion.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Contains relevant internal information about parallel regions, including the threads and the function to be executed.

--- a/DotMP/Init.cs
+++ b/DotMP/Init.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Encapsulates a Thread object with information about its progress through a parallel for loop.

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Contains all of the scheduling code for parallel for loops.

--- a/DotMP/Lock.cs
+++ b/DotMP/Lock.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// A lock that can be used in a parallel region.

--- a/DotMP/Operations.cs
+++ b/DotMP/Operations.cs
@@ -1,4 +1,4 @@
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Enum that represents the different operations that can be used in a for-reduction.

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Action delegate that takes an int and a ref T as parameters.
@@ -13,7 +13,7 @@ namespace OpenMP
     public delegate void ActionRef<T>(ref T a, int i);
 
     /// <summary>
-    /// The main class of OpenMP.NET.
+    /// The main class of DotMP.
     /// Contains all the main methods for parallelism.
     /// For users, this is the main class you want to worry about, along with Locking, Lock, Shared, and Atomic
     /// </summary>
@@ -43,7 +43,7 @@ namespace OpenMP
         /// </summary>
         private static volatile int found_criticals = 0;
         /// <summary>
-        /// Barrier object for OpenMP.Parallel.Barrier()
+        /// Barrier object for DotMP.Parallel.Barrier()
         /// </summary>
         private static volatile Barrier barrier;
         /// <summary>
@@ -672,7 +672,7 @@ namespace OpenMP
 
         /// <summary>
         /// Enables nested parallelism.
-        /// This function is not implemented, as nested parallelism does not exist in the current version of OpenMP.NET.
+        /// This function is not implemented, as nested parallelism does not exist in the current version of DotMP.
         /// There are no plans to implement nested parallelism at the moment.
         /// </summary>
         /// <param name="_">Unused.</param>

--- a/DotMP/Sections.cs
+++ b/DotMP/Sections.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// Static class that contains necessary information for sections.

--- a/DotMP/Shared.cs
+++ b/DotMP/Shared.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 
-namespace OpenMP
+namespace DotMP
 {
     /// <summary>
     /// A shared variable that can be used in a parallel region.
     /// This allows for a variable to be declared inside of a parallel region that is shared among all threads, which has some nice use cases.
-    /// The OpenMP.NET-parallelized Conjugate Gradient example shows this off fairly well inside of the SpMV function.
+    /// The DotMP-parallelized Conjugate Gradient example shows this off fairly well inside of the SpMV function.
     /// </summary>
     /// <typeparam name="T">The type of the shared variable.</typeparam>
     public class Shared<T>
@@ -29,13 +29,13 @@ namespace OpenMP
         /// <param name="value">Initial starting value of the shared variable.</param>
         public Shared(string name, T value)
         {
-            OpenMP.Parallel.Master(() =>
+            DotMP.Parallel.Master(() =>
             {
                 shared[name] = value;
             });
             this.name = name;
 
-            OpenMP.Parallel.Barrier();
+            DotMP.Parallel.Barrier();
         }
 
         /// <summary>
@@ -45,8 +45,8 @@ namespace OpenMP
         /// </summary>
         public void Clear()
         {
-            OpenMP.Parallel.Master(() => shared.Remove(name));
-            OpenMP.Parallel.Barrier();
+            DotMP.Parallel.Master(() => shared.Remove(name));
+            DotMP.Parallel.Barrier();
         }
 
         /// <summary>

--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "OpenMP.NET"
+PROJECT_NAME           = "DotMP"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -865,8 +865,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = README.md
-INPUT                  += ./OpenMP.NET
-INPUT                  += ./OpenMP.NET.Tests
+INPUT                  += ./DotMP
+INPUT                  += ./DotMP-Tests
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ examples-cs:
 	$(DN) build -c Release examples/CSParallel/GEMM
 
 examples-omp:
-	$(DN) build -c Release examples/OpenMP.NET/ConjugateGradient
-	$(DN) build -c Release examples/OpenMP.NET/HeatTransfer
-	$(DN) build -c Release examples/OpenMP.NET/GEMM
+	$(DN) build -c Release examples/DotMP/ConjugateGradient
+	$(DN) build -c Release examples/DotMP/HeatTransfer
+	$(DN) build -c Release examples/DotMP/GEMM
 
 examples-seq:
 	$(DN) build -c Release examples/Serial/ConjugateGradient
@@ -20,27 +20,27 @@ examples-seq:
 	$(DN) build -c Release examples/Serial/GEMM
 
 tests:
-	$(DN) build -c Release OpenMP.NET.Tests
+	$(DN) build -c Release DotMP-Tests
 
 test:
-	$(DN) test -c Release OpenMP.NET.Tests
+	$(DN) test -c Release DotMP-Tests
 
-build: OpenMP.NET
-	$(DN) build -c Release OpenMP.NET
+build:
+	$(DN) build -c Release DotMP
 
 docs:
 	doxygen
 
 clean:
 	rm -rf docs
-	rm -rf OpenMP.NET/bin OpenMP.NET/obj
-	rm -rf OpenMP.NET.Tests/bin OpenMP.NET.Tests/obj
+	rm -rf DotMP/bin DotMP/obj
+	rm -rf DotMP-Tests/bin DotMP-Tests/obj
 	rm -rf examples/CSParallel/ConjugateGradient/bin examples/CSParallel/ConjugateGradient/obj
 	rm -rf examples/CSParallel/HeatTransfer/bin examples/CSParallel/HeatTransfer/obj
 	rm -rf examples/CSParallel/GEMM/bin examples/CSParallel/GEMM/obj
-	rm -rf examples/OpenMP.NET/ConjugateGradient/bin examples/OpenMP.NET/ConjugateGradient/obj
-	rm -rf examples/OpenMP.NET/HeatTransfer/bin examples/OpenMP.NET/HeatTransfer/obj
-	rm -rf examples/OpenMP.NET/GEMM/bin examples/OpenMP.NET/GEMM/obj
+	rm -rf examples/DotMP/ConjugateGradient/bin examples/DotMP/ConjugateGradient/obj
+	rm -rf examples/DotMP/HeatTransfer/bin examples/DotMP/HeatTransfer/obj
+	rm -rf examples/DotMP/GEMM/bin examples/DotMP/GEMM/obj
 	rm -rf examples/Serial/ConjugateGradient/bin examples/Serial/ConjugateGradient/obj
 	rm -rf examples/Serial/HeatTransfer/bin examples/Serial/HeatTransfer/obj
 	rm -rf examples/Serial/GEMM/bin examples/Serial/GEMM/obj

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# [DotMP](https://github.com/computablee/OpenMP.NET)
+# [DotMP](https://github.com/computablee/DotMP)
 A library for writing OpenMP-style parallel code in .NET.
 Inspired by the fork-join paradigm of OpenMP, and attempts to replicate the OpenMP programming style as faithfully as possible, though breaking spec at times.
 
 ## Building DotMP from Source
 First, clone DotMP and navigate to the source directory:
 ```sh
-git clone git@github.com:computablee/OpenMP.NET.git
-cd OpenMP.NET
+git clone git@github.com:computablee/ODotMP.git
+cd DotMP
 ```
 
 DotMP can be built using the `make` command.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# [OpenMP.NET](https://github.com/computablee/OpenMP.NET)
+# [DotMP](https://github.com/computablee/OpenMP.NET)
 A library for writing OpenMP-style parallel code in .NET.
 Inspired by the fork-join paradigm of OpenMP, and attempts to replicate the OpenMP programming style as faithfully as possible, though breaking spec at times.
 
-## Building OpenMP.NET from Source
-First, clone OpenMP.NET and navigate to the source directory:
+## Building DotMP from Source
+First, clone DotMP and navigate to the source directory:
 ```sh
 git clone git@github.com:computablee/OpenMP.NET.git
 cd OpenMP.NET
 ```
 
-OpenMP.NET can be built using the `make` command.
+DotMP can be built using the `make` command.
 To build the entire project, including all tests, examples, and documentation, run the following command:
 ```sh
 make
@@ -34,7 +34,7 @@ To build only the examples, run the following command:
 ```sh
 make examples
 ```
-This will build all of the examples, including the native C# parallelized, the OpenMP.NET parallelized, and the sequential examples.
+This will build all of the examples, including the native C# parallelized, the DotMP parallelized, and the sequential examples.
 You can also individually build each of these classes of examples by running one or all of the following commands:
 ```sh
 make examples-cs
@@ -61,9 +61,9 @@ Given the OpenMP:
     work();
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.ParallelRegion(() => {
+DotMP.Parallel.ParallelRegion(() => {
     work();
 });
 ```
@@ -79,20 +79,20 @@ for (int i = a, i < b; i++)
     work(i);
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.For(a, b, i => {
+DotMP.Parallel.For(a, b, i => {
     work(i);
 });
 ```
 This function supports the `schedule` optional parameter, which sets the parallel scheduler to use.
-Permissible values are `OpenMP.Parallel.Schedule.Static`, `OpenMP.Parallel.Schedule.Dynamic`, and `OpenMP.Parallel.Schedule.Guided`.
-The default value is `OpenMP.Parallel.Schedule.Static`.
+Permissible values are `DotMP.Parallel.Schedule.Static`, `DotMP.Parallel.Schedule.Dynamic`, `DotMP.Parallel.Schedule.Guided`, and `DotMP.Parallel.Schedule.Runtime`.
+The default value is `DotMP.Parallel.Schedule.Static`.
 
 This function supports the `chunk_size` optional parameter, which sets the chunk size for the scheduler to use.
 The default value is dependent on the scheduler and is not documented, as it may change from version to version.
 
-The behavior of `OpenMP.Parallel.For` is undefined if not used within a `ParallelRegion`.
+The behavior of `DotMP.Parallel.For` is undefined if not used within a `ParallelRegion`.
 
 ### Parallel For
 Given the OpenMP:
@@ -103,9 +103,9 @@ for (int i = a, i < b; i++)
     work(i);
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.ParallelFor(a, b, i => {
+DotMP.Parallel.ParallelFor(a, b, i => {
     work(i);
 });
 ```
@@ -122,16 +122,16 @@ for (int i = a; i < b; i++)
     local `op` f(i);
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
 type local = c;
 
-OpenMP.Parallel.ForReduction(a, b, op, ref local, (ref type local, int i) => {
+DotMP.Parallel.ForReduction(a, b, op, ref local, (ref type local, int i) => {
     local `op` f(i);
 });
 ```
-`op` is a value provided by the `OpenMP.Operations` enum, which supports the values `Add`, `Subtract`, `Multiply`, `BinaryAnd`, `BinaryOr`, `BinaryXor`, `BooleanAnd`, `BooleanOr`, `Min`, and `Max`.
-The operation on `local` is an operator corresponding to the operator specified by `OpenMP.Operations`, including `+`, `-`, `*`, `&`, `|`, `^`, and so on.
+`op` is a value provided by the `DotMP.Operations` enum, which supports the values `Add`, `Subtract`, `Multiply`, `BinaryAnd`, `BinaryOr`, `BinaryXor`, `BooleanAnd`, `BooleanOr`, `Min`, and `Max`.
+The operation on `local` is an operator corresponding to the operator specified by `DotMP.Operations`, including `+`, `-`, `*`, `&`, `|`, `^`, and so on.
 
 This function supports all of the optional parameters of `For`.
 
@@ -146,11 +146,11 @@ for (int i = a; i < b; i++)
     local `op` f(i);
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
 type local = c;
 
-OpenMP.Parallel.ParallelForReduction(a, b, op, ref local, (ref type local, int i) => {
+DotMP.Parallel.ParallelForReduction(a, b, op, ref local, (ref type local, int i) => {
     local `op` f(i);
 });
 ```
@@ -171,13 +171,13 @@ Given the OpenMP:
     }
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.Sections(() => {
-    OpenMP.Parallel.Section(() => {
+DotMP.Parallel.Sections(() => {
+    DotMP.Parallel.Section(() => {
         work();
     });
-    OpenMP.Parallel.Section(() => {
+    DotMP.Parallel.Section(() => {
         work();
     });
 });
@@ -198,18 +198,18 @@ Given the OpenMP:
     }
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.ParallelSections(() => {
-    OpenMP.Parallel.Section(() => {
+DotMP.Parallel.ParallelSections(() => {
+    DotMP.Parallel.Section(() => {
         work();
     });
-    OpenMP.Parallel.Section(() => {
+    DotMP.Parallel.Section(() => {
         work();
     });
 });
 ```
-This function supports the optional parameter `num_threads` from `OpenMP.Parallel.ParallelRegion`.
+This function supports the optional parameter `num_threads` from `DotMP.Parallel.ParallelRegion`.
 
 ### Critical
 Given the OpenMP:
@@ -219,9 +219,9 @@ Given the OpenMP:
     work();
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.Critical(id, () => {
+DotMP.Parallel.Critical(id, () => {
     work();
 });
 ```
@@ -234,9 +234,9 @@ Given the OpenMP:
 ```c
 #pragma omp barrier
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.Barrier();
+DotMP.Parallel.Barrier();
 ```
 
 ### Master
@@ -247,9 +247,9 @@ Given the OpenMP:
     work();
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.Master(() => {
+DotMP.Parallel.Master(() => {
     work();
 });
 ```
@@ -263,9 +263,9 @@ Given the OpenMP:
     work();
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.Single(id, () => {
+DotMP.Parallel.Single(id, () => {
     work();
 });
 ```
@@ -284,9 +284,9 @@ Given the OpenMP:
     work();
 }
 ```
-OpenMP.NET provides:
+DotMP provides:
 ```cs
-OpenMP.Parallel.Ordered(id, () => {
+DotMP.Parallel.Ordered(id, () => {
     work();
 });
 ```
@@ -303,46 +303,46 @@ a op b;
 ```
 where `op` is some supported operator.
 
-OpenMP.NET supports a subset of this for the `int`, `uint`, `long`, and `ulong` types.
+DotMP supports a subset of this for the `int`, `uint`, `long`, and `ulong` types.
 The only implemented atomic operations are `a += b`, `a &= b`, `a |= b`, `++a`, and `--a`.
 `a -= b` is implemented, but for signed types only, due to restrictions interfacting with C#'s `Interlocked` class.
 
 The following table documents the supported atomics:
 
-| Operation | OpenMP.NET function           |
+| Operation | DotMP function           |
 ------------|--------------------------------
-| `a += b`  | `OpenMP.Atomic.Add(ref a, b)` |
-| `a -= b`  | `OpenMP.Atomic.Sub(ref a, b)` |
-| `a &= b`  | `OpenMP.Atomic.And(ref a, b)` |
-| `a \|= b` | `OpenMP.Atomic.Or(ref a, b)`  |
-| `++a`     | `OpenMP.Atomic.Inc(ref a)`    |
-| `--a`     | `OpenMP.Atomic.Dec(ref a)`    |
+| `a += b`  | `DotMP.Atomic.Add(ref a, b)` |
+| `a -= b`  | `DotMP.Atomic.Sub(ref a, b)` |
+| `a &= b`  | `DotMP.Atomic.And(ref a, b)` |
+| `a \|= b` | `DotMP.Atomic.Or(ref a, b)`  |
+| `++a`     | `DotMP.Atomic.Inc(ref a)`    |
+| `--a`     | `DotMP.Atomic.Dec(ref a)`    |
 
 For atomic operations like compare-exchange, we recommend interfacting directly with `System.Threading.Interlocked`.
-For non-supported atomic operations or types, we recommend using `OpenMP.Parallel.Critical`.
+For non-supported atomic operations or types, we recommend using `DotMP.Parallel.Critical`.
 This is more of a limitation of the underlying hardware than anything.
 
 ## Locks
-OpenMP.NET supports OpenMP-style locks.
+DotMP supports OpenMP-style locks.
 It is recommended to use C#'s native `lock` keyword where possible for performance.
 However, this API is provided to those who want the familiarity of OpenMP locks.
 
-OpenMP.NET supports the `OpenMP.Lock` object, which is the replacement for `omp_lock_t`.
+DotMP supports the `DotMP.Lock` object, which is the replacement for `omp_lock_t`.
 `omp_init_lock` and `omp_destroy_lock` are not implemented.
-Instead, users should instantiate the `OpenMP.Lock` object using the `new` keyword.
+Instead, users should instantiate the `DotMP.Lock` object using the `new` keyword.
 
-OpenMP.NET provides the following functions:
+DotMP provides the following functions:
 
-| <omp.h> function     | OpenMP.NET function        | Comments
+| <omp.h> function     | DotMP function        | Comments
 -----------------------|----------------------------|---------
-| omp_set_lock(lock)   | OpenMP.Locking.Set(lock)   | Halt the current thread until the lock is obtained
-| omp_unset_lock(lock) | OpenMP.Locking.Unset(lock) | Free the current lock, making it available for other threads
-| omp_test_lock(lock)  | OpenMP.Locking.Test(lock)  | Attempt to obtain a lock without blocking, returns true if locking is successful
+| omp_set_lock(lock)   | DotMP.Locking.Set(lock)   | Halt the current thread until the lock is obtained
+| omp_unset_lock(lock) | DotMP.Locking.Unset(lock) | Free the current lock, making it available for other threads
+| omp_test_lock(lock)  | DotMP.Locking.Test(lock)  | Attempt to obtain a lock without blocking, returns true if locking is successful
 
 ## Shared Memory
 
-OpenMP.NET supports an API for declaring thread-shared memory within a parallel region.
-Shared memory is provided through the `OpenMP.Shared` class.
+DotMP supports an API for declaring thread-shared memory within a parallel region.
+Shared memory is provided through the `DotMP.Shared` class.
 
 The following provides an example of a parallel vector initialization:
 ```cs
@@ -350,10 +350,10 @@ static void InitVector()
 {
     double[] returnVector;
     
-    OpenMP.Parallel.ParallelRegion(() =>
+    DotMP.Parallel.ParallelRegion(() =>
     {
-        OpenMP.Shared<double[]> vec = new OpenMP.Shared<double[]>("vec", new double[1024]);
-        OpenMP.Parallel.For(0, 1024, i =>
+        DotMP.Shared<double[]> vec = new DotMP.Shared<double[]>("vec", new double[1024]);
+        DotMP.Parallel.For(0, 1024, i =>
         {
             vec.Get()[i] = 1.0;
         });
@@ -366,7 +366,7 @@ static void InitVector()
 }
 ```
 
-The `OpenMP.Shared` class supports the following methods:
+The `DotMP.Shared` class supports the following methods:
 | Method                            | Action 
 ------------------------------------|-------
 | Constructor(string name, T value) | Initializes a shared variable with name `name` and starting value `value`
@@ -374,24 +374,24 @@ The `OpenMP.Shared` class supports the following methods:
 | Set(T value)                      | Sets a shared variable to value `value`
 | Get()                             | Gets a shared variable
 
-The `OpenMP.Shared` constructor and `Clear()` methods serve as implicit barriers, ensuring that all threads can access the memory before proceeding.
+The `DotMP.Shared` constructor and `Clear()` methods serve as implicit barriers, ensuring that all threads can access the memory before proceeding.
 
 ## Supported Functions
 
-OpenMP.NET provides an analog of the following functions:
+DotMP provides an analog of the following functions:
 
-| <omp.h> function         | OpenMP.NET function                | Comments
+| <omp.h> function         | DotMP function                | Comments
 ---------------------------|------------------------------------|---------
-| omp_get_num_procs()      | OpenMP.Parallel.GetNumProcs()      | Returns the number of logical threads on the system
-| omp_get_num_threads()    | OpenMP.Parallel.GetNumThreads()    | Returns the number of active threads in the current region
-| omp_set_num_threads(int) | OpenMP.Parallel.SetNumThreads(int) | Sets the number of threads for the next parallel region to use
-| omp_get_thread_num()     | OpenMP.Parallel.GetThreadNum()     | Gets the ID of the current thread
-| omp_get_max_threads()    | OpenMP.Parallel.GetMaxThreads()    | Gets the maximum number of threads the runtime may use in the next region
-| omp_in_parallel()        | OpenMP.Parallel.InParallel()       | Returns true if called from within a parallel region
-| omp_set_dynamic(int)     | OpenMP.Parallel.SetDynamic()       | Tells the runtime to dynamically adjust the number of threads, can disable by calling SetNumThreads
-| omp_get_dynamic()        | OpenMP.Parallel.GetDynamic()       | Returns true if the runtime can dynamically adjust the number of threads
-| omp_set_nested(int)      | OpenMP.Parallel.SetNested(bool)    | Returns a NotImplementedException
-| omp_get_nested()         | OpenMP.Parallel.GetNested()        | Returns false
-| omp_get_wtime()          | OpenMP.Parallel.GetWTime()         | Returns the number of seconds since the Unix Epoch as a double
-| N/A                      | OpenMP.Parallel.GetSchedule()      | Gets the current schedule of the parallel for loop
-| N/A                      | OpenMP.Parallel.GetChunkSize()     | Gets the current chunk size of the parallel for loop
+| omp_get_num_procs()      | DotMP.Parallel.GetNumProcs()      | Returns the number of logical threads on the system
+| omp_get_num_threads()    | DotMP.Parallel.GetNumThreads()    | Returns the number of active threads in the current region
+| omp_set_num_threads(int) | DotMP.Parallel.SetNumThreads(int) | Sets the number of threads for the next parallel region to use
+| omp_get_thread_num()     | DotMP.Parallel.GetThreadNum()     | Gets the ID of the current thread
+| omp_get_max_threads()    | DotMP.Parallel.GetMaxThreads()    | Gets the maximum number of threads the runtime may use in the next region
+| omp_in_parallel()        | DotMP.Parallel.InParallel()       | Returns true if called from within a parallel region
+| omp_set_dynamic(int)     | DotMP.Parallel.SetDynamic()       | Tells the runtime to dynamically adjust the number of threads, can disable by calling SetNumThreads
+| omp_get_dynamic()        | DotMP.Parallel.GetDynamic()       | Returns true if the runtime can dynamically adjust the number of threads
+| omp_set_nested(int)      | DotMP.Parallel.SetNested(bool)    | Returns a NotImplementedException
+| omp_get_nested()         | DotMP.Parallel.GetNested()        | Returns false
+| omp_get_wtime()          | DotMP.Parallel.GetWTime()         | Returns the number of seconds since the Unix Epoch as a double
+| N/A                      | DotMP.Parallel.GetSchedule()      | Gets the current schedule of the parallel for loop
+| N/A                      | DotMP.Parallel.GetChunkSize()     | Gets the current chunk size of the parallel for loop

--- a/examples/CSParallel/ConjugateGradient/ConjugateGradient.csproj
+++ b/examples/CSParallel/ConjugateGradient/ConjugateGradient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/examples/CSParallel/ConjugateGradient/Program.cs
+++ b/examples/CSParallel/ConjugateGradient/Program.cs
@@ -244,9 +244,9 @@ class Driver
         for (int i = 0; i < numRuns; i++)
         {
             //time the algorithm
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             (x, iters) = ConjugateGradient.DoConjugateGradient(A, b, 1000, 0.01);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/CSParallel/GEMM/GEMM.csproj
+++ b/examples/CSParallel/GEMM/GEMM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/examples/CSParallel/GEMM/Program.cs
+++ b/examples/CSParallel/GEMM/Program.cs
@@ -101,9 +101,9 @@ class Driver
         for (int i = 0; i < numRuns; i++)
         {
             //time the algorithm
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             GEMM.DoGEMM(A, B, C);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/CSParallel/HeatTransfer/HeatTransfer.csproj
+++ b/examples/CSParallel/HeatTransfer/HeatTransfer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/examples/CSParallel/HeatTransfer/Program.cs
+++ b/examples/CSParallel/HeatTransfer/Program.cs
@@ -103,9 +103,9 @@ class Driver
             grid[0, dim / 2] = 100.0;
 
             //do the simulation
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             HeatTransfer.DoSimulation(grid, steps, dim);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/DotMP/ConjugateGradient/ConjugateGradient.csproj
+++ b/examples/DotMP/ConjugateGradient/ConjugateGradient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/examples/DotMP/GEMM/GEMM.csproj
+++ b/examples/DotMP/GEMM/GEMM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/examples/DotMP/GEMM/Program.cs
+++ b/examples/DotMP/GEMM/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using OpenMP;
+using DotMP;
 
 static class GEMM
 {
@@ -12,7 +12,7 @@ static class GEMM
         int k = A[0].Length;
 
         //parallel for loop on the outermost loop
-        OpenMP.Parallel.ParallelFor(0, m, schedule: OpenMP.Parallel.Schedule.Dynamic, action: i =>
+        DotMP.Parallel.ParallelFor(0, m, schedule: DotMP.Parallel.Schedule.Dynamic, action: i =>
         {
             //inner loop is serial
             for (int j = 0; j < n; j++)
@@ -101,9 +101,9 @@ class Driver
         for (int i = 0; i < numRuns; i++)
         {
             //time the algorithm
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             GEMM.DoGEMM(A, B, C);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/DotMP/HeatTransfer/HeatTransfer.csproj
+++ b/examples/DotMP/HeatTransfer/HeatTransfer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/examples/DotMP/HeatTransfer/Program.cs
+++ b/examples/DotMP/HeatTransfer/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using OpenMP;
+using DotMP;
 
 static class HeatTransfer
 {
@@ -8,7 +8,7 @@ static class HeatTransfer
     private static void DoStep(double[,] grid, double[,] scratch, int dim)
     {
         //iterate over all cells not on the border
-        OpenMP.Parallel.For(1, dim - 1, schedule: OpenMP.Parallel.Schedule.Dynamic, action: i =>
+        DotMP.Parallel.For(1, dim - 1, schedule: DotMP.Parallel.Schedule.Dynamic, action: i =>
         {
             for (int j = 1; j < dim - 1; j++)
             {
@@ -18,7 +18,7 @@ static class HeatTransfer
         });
 
         //copy the scratch array to the grid array
-        OpenMP.Parallel.For(1, dim - 1, schedule: OpenMP.Parallel.Schedule.Static, action: i =>
+        DotMP.Parallel.For(1, dim - 1, schedule: DotMP.Parallel.Schedule.Static, action: i =>
         {
             for (int j = 1; j < dim - 1; j++)
             {
@@ -35,7 +35,7 @@ static class HeatTransfer
         Array.Copy(grid, scratch, dim * dim);
 
         //do the steps
-        OpenMP.Parallel.ParallelRegion(num_threads: 6, action: () =>
+        DotMP.Parallel.ParallelRegion(num_threads: 6, action: () =>
         {
             for (int i = 0; i < steps; i++)
             {
@@ -106,9 +106,9 @@ class Driver
             grid[0, dim / 2] = 100.0;
 
             //do the simulation
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             HeatTransfer.DoSimulation(grid, steps, dim);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/Serial/ConjugateGradient/ConjugateGradient.csproj
+++ b/examples/Serial/ConjugateGradient/ConjugateGradient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/examples/Serial/ConjugateGradient/Program.cs
+++ b/examples/Serial/ConjugateGradient/Program.cs
@@ -1,4 +1,4 @@
-﻿using OpenMP;
+﻿using DotMP;
 using System;
 using System.IO;
 using System.Threading;
@@ -257,9 +257,9 @@ class Driver
         for (int i = 0; i < numRuns; i++)
         {
             //time the algorithm
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             (x, iters) = ConjugateGradient.DoConjugateGradient(A, b, 1000, 0.01);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/Serial/GEMM/GEMM.csproj
+++ b/examples/Serial/GEMM/GEMM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/examples/Serial/GEMM/Program.cs
+++ b/examples/Serial/GEMM/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using OpenMP;
+using DotMP;
 
 static class GEMM
 {
@@ -101,9 +101,9 @@ class Driver
         for (int i = 0; i < numRuns; i++)
         {
             //time the algorithm
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             GEMM.DoGEMM(A, B, C);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;

--- a/examples/Serial/HeatTransfer/HeatTransfer.csproj
+++ b/examples/Serial/HeatTransfer/HeatTransfer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenMP.NET\OpenMP.NET.csproj" />
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/examples/Serial/HeatTransfer/Program.cs
+++ b/examples/Serial/HeatTransfer/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using OpenMP;
+using DotMP;
 
 static class HeatTransfer
 {
@@ -103,9 +103,9 @@ class Driver
             grid[0, dim / 2] = 100.0;
 
             //do the simulation
-            double tick = OpenMP.Parallel.GetWTime();
+            double tick = DotMP.Parallel.GetWTime();
             HeatTransfer.DoSimulation(grid, steps, dim);
-            double tock = OpenMP.Parallel.GetWTime();
+            double tock = DotMP.Parallel.GetWTime();
 
             //update min, max, avg
             tock = tock - tick;


### PR DESCRIPTION
Begin renaming project to DotMP in accordance with OpenMP's trademark usage guidelines.