### PR TITLE
Several QOL improvements

### DIFF
--- a/DotMP-Tests/DotMP-Tests.sln
+++ b/DotMP-Tests/DotMP-Tests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotMP-Tests", "DotMP-Tests.csproj", "{19803A2D-8BE9-4C43-B6B3-0651D9C30872}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{19803A2D-8BE9-4C43-B6B3-0651D9C30872}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19803A2D-8BE9-4C43-B6B3-0651D9C30872}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19803A2D-8BE9-4C43-B6B3-0651D9C30872}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19803A2D-8BE9-4C43-B6B3-0651D9C30872}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A8FFED55-3020-45AD-89C2-C19A93EAB95C}
+	EndGlobalSection
+EndGlobal

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -358,7 +358,7 @@ namespace DotMPTests
             DotMP.Parallel.ParallelRegion(() =>
             {
                 DotMP.Shared<int> s;
-                using (s = new DotMP.Shared<int>("s", 6))
+                using (s = DotMP.Shared.Create("s", 6))
                 {
                     s.Get().Should().Be(6);
                     (s + 1).Should().Be(7);
@@ -382,8 +382,8 @@ namespace DotMPTests
 
             DotMP.Parallel.ParallelRegion(() =>
             {
-                DotMP.SharedEnumerable<double> vec;
-                using (vec = new DotMP.SharedEnumerable<double>("vec", new double[1024]))
+                DotMP.SharedEnumerable<double, double[]> vec;
+                using (vec = DotMP.SharedEnumerable.Create("vec", new double[1024]))
                 {
                     DotMP.Parallel.For(0, 1024, i =>
                     {
@@ -402,15 +402,18 @@ namespace DotMPTests
 
             DotMP.Parallel.ParallelRegion(() =>
             {
-                DotMP.SharedEnumerable<double> a = new DotMP.SharedEnumerable<double>("a", new double[1024]);
-                DotMP.SharedEnumerable<double> x = new DotMP.SharedEnumerable<double>("x", new List<double>(new double[1024]));
+                var a = DotMP.SharedEnumerable.Create("a", new double[1024]);
+                var x = DotMP.SharedEnumerable.Create("x", new List<double>(new double[1024]));
 
                 a[0] = x[0];
                 double[] a_arr = a;
                 List<double> x_arr = x;
 
-                a_arr = a.GetArray();
-                x_arr = x.GetList();
+                DotMP.Parallel.Barrier();
+                a.Dispose();
+                x.Dispose();
+                a.Disposed.Should().BeTrue();
+                x.Disposed.Should().BeTrue();
             });
         }
 

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -356,14 +356,17 @@ namespace DotMPTests
         {
             DotMP.Parallel.ParallelRegion(() =>
             {
-                DotMP.Shared<int> s = new DotMP.Shared<int>("s", 6);
-                s.Get().Should().Be(6);
-                DotMP.Parallel.Barrier();
-                DotMP.Parallel.Master(() => s.Set(7));
-                DotMP.Parallel.Barrier();
-                s.Get().Should().Be(7);
-                DotMP.Parallel.Barrier();
-                s.Clear();
+                DotMP.Shared<int> s;
+                using (s = new DotMP.Shared<int>("s", 6))
+                {
+                    s.Get().Should().Be(6);
+                    DotMP.Parallel.Barrier();
+                    DotMP.Parallel.Master(() => s.Set(7));
+                    DotMP.Parallel.Barrier();
+                    s.Get().Should().Be(7);
+                    DotMP.Parallel.Barrier();
+                }
+                s.Disposed.Should().BeTrue();
             });
         }
 

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -330,22 +330,22 @@ namespace DotMPTests
 
             DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                DotMP.Locking.Set(l);
+                DotMP.Lock.Set(l);
                 Thread.Sleep(100);
-                DotMP.Locking.Unset(l);
+                DotMP.Lock.Unset(l);
             });
 
             double elapsed = DotMP.Parallel.GetWTime() - time;
             elapsed.Should().BeGreaterThan(1.6);
 
-            DotMP.Locking.Test(l).Should().BeTrue();
-            DotMP.Locking.Test(l).Should().BeFalse();
-            DotMP.Locking.Test(l).Should().BeFalse();
-            DotMP.Locking.Unset(l);
-            DotMP.Locking.Test(l).Should().BeTrue();
-            DotMP.Locking.Test(l).Should().BeFalse();
-            DotMP.Locking.Test(l).Should().BeFalse();
-            DotMP.Locking.Unset(l);
+            DotMP.Lock.Test(l).Should().BeTrue();
+            DotMP.Lock.Test(l).Should().BeFalse();
+            DotMP.Lock.Test(l).Should().BeFalse();
+            DotMP.Lock.Unset(l);
+            DotMP.Lock.Test(l).Should().BeTrue();
+            DotMP.Lock.Test(l).Should().BeFalse();
+            DotMP.Lock.Test(l).Should().BeFalse();
+            DotMP.Lock.Unset(l);
         }
 
         /// <summary>

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -93,16 +93,16 @@ namespace DotMPTests
         public void Schedule_runtime_works()
         {
             Environment.SetEnvironmentVariable("OMP_SCHEDULE", "guided,2");
-            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Parallel.Schedule.Runtime, action: i =>
+            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Schedule.Runtime, action: i =>
             {
-                DotMP.Parallel.GetSchedule().Should().Be(DotMP.Parallel.Schedule.Guided);
+                DotMP.Parallel.GetSchedule().Should().Be(DotMP.Schedule.Guided);
                 DotMP.Parallel.GetChunkSize().Should().Be(2);
             });
 
             Environment.SetEnvironmentVariable("OMP_SCHEDULE", "dynamic,4");
-            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Parallel.Schedule.Runtime, action: i =>
+            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Schedule.Runtime, action: i =>
             {
-                DotMP.Parallel.GetSchedule().Should().Be(DotMP.Parallel.Schedule.Dynamic);
+                DotMP.Parallel.GetSchedule().Should().Be(DotMP.Schedule.Dynamic);
                 DotMP.Parallel.GetChunkSize().Should().Be(4);
             });
         }
@@ -192,7 +192,7 @@ namespace DotMPTests
             uint threads = 8;
             int[] incrementing = new int[1024];
 
-            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Parallel.Schedule.Static,
+            DotMP.Parallel.ParallelFor(0, 1024, schedule: DotMP.Schedule.Static,
                                         num_threads: threads, action: i =>
             {
                 DotMP.Parallel.Ordered(0, () => incrementing[i] = i);
@@ -212,12 +212,12 @@ namespace DotMPTests
         {
             int total = 0;
 
-            DotMP.Parallel.ParallelForReduction(0, 1024, DotMP.Operations.Add, ref total, num_threads: 8, schedule: DotMP.Parallel.Schedule.Static, action: (ref int total, int i) =>
+            DotMP.Parallel.ParallelForReduction(0, 1024, DotMP.Operations.Add, ref total, num_threads: 8, schedule: DotMP.Schedule.Static, action: (ref int total, int i) =>
             {
                 total += i;
             });
 
-            DotMP.Parallel.ParallelForReduction(0, 1024, DotMP.Operations.Add, ref total, num_threads: 8, schedule: DotMP.Parallel.Schedule.Static, action: (ref int total, int i) =>
+            DotMP.Parallel.ParallelForReduction(0, 1024, DotMP.Operations.Add, ref total, num_threads: 8, schedule: DotMP.Schedule.Static, action: (ref int total, int i) =>
             {
                 total += i;
             });
@@ -481,7 +481,7 @@ namespace DotMPTests
             {
                 if (inParallel)
                 {
-                    DotMP.Parallel.ParallelFor(0, WORKLOAD, schedule: DotMP.Parallel.Schedule.Guided,
+                    DotMP.Parallel.ParallelFor(0, WORKLOAD, schedule: DotMP.Schedule.Guided,
                         action: j => InnerWorkload(j, a, b, c));
                 }
                 else
@@ -543,7 +543,7 @@ namespace DotMPTests
 
             DotMP.Parallel.ParallelRegion(() =>
             {
-                DotMP.Parallel.For(0, x.Length, schedule: DotMP.Parallel.Schedule.Guided, action: i =>
+                DotMP.Parallel.For(0, x.Length, schedule: DotMP.Schedule.Guided, action: i =>
                 {
                     z[i] = a * x[i] + y[i];
                 });
@@ -563,7 +563,7 @@ namespace DotMPTests
         {
             float[] z = new float[x.Length];
 
-            DotMP.Parallel.ParallelFor(0, x.Length, schedule: DotMP.Parallel.Schedule.Guided, action: i =>
+            DotMP.Parallel.ParallelFor(0, x.Length, schedule: DotMP.Schedule.Guided, action: i =>
             {
                 z[i] = a * x[i] + y[i];
             });
@@ -591,7 +591,7 @@ namespace DotMPTests
                     int id1 = DotMP.Parallel.Critical(0, () => ++x);
                     int id2 = -1;
 
-                    DotMP.Parallel.For(0, 100, schedule: DotMP.Parallel.Schedule.Static, action: j =>
+                    DotMP.Parallel.For(0, 100, schedule: DotMP.Schedule.Static, action: j =>
                     {
                         if (two_regions)
                         {

--- a/DotMP/Exceptions.cs
+++ b/DotMP/Exceptions.cs
@@ -5,7 +5,7 @@ namespace DotMP
     /// <summary>
     /// Exception thrown if a parallel-only construct is used outside of a parallel region.
     /// </summary>
-    class NotInParallelRegionException : Exception
+    public class NotInParallelRegionException : Exception
     {
         public NotInParallelRegionException() { }
 
@@ -17,7 +17,7 @@ namespace DotMP
     /// <summary>
     /// Exception thrown if a sections-only construct is used outside of a sections region.
     /// </summary>
-    class NotInSectionsRegionException : Exception
+    public class NotInSectionsRegionException : Exception
     {
         public NotInSectionsRegionException() { }
 
@@ -29,12 +29,24 @@ namespace DotMP
     /// <summary>
     /// Exception thrown if a Parallel.ParallelRegion is created inside of another Parallel.ParallelRegion.
     /// </summary>
-    class CannotPerformNestedParallelismException : Exception
+    public class CannotPerformNestedParallelismException : Exception
     {
         public CannotPerformNestedParallelismException() { }
 
         public CannotPerformNestedParallelismException(string msg) : base(msg) { }
 
         public CannotPerformNestedParallelismException(string msg, Exception ex) : base(msg, ex) { }
+    }
+
+    /// <summary>
+    /// Exception thrown if a Parallel.For or Parallel.ForReduction<T> is created inside of another Parallel.For or Parallel.ForReduction<T>.
+    /// </summary>
+    public class CannotPerformNestedForException : Exception
+    {
+        public CannotPerformNestedForException() { }
+
+        public CannotPerformNestedForException(string msg) : base(msg) { }
+
+        public CannotPerformNestedForException(string msg, Exception ex) : base(msg, ex) { }
     }
 }

--- a/DotMP/Exceptions.cs
+++ b/DotMP/Exceptions.cs
@@ -25,4 +25,16 @@ namespace DotMP
 
         public NotInSectionsRegionException(string msg, Exception ex) : base(msg, ex) { }
     }
+
+    /// <summary>
+    /// Exception thrown if a Parallel.ParallelRegion is created inside of another Parallel.ParallelRegion.
+    /// </summary>
+    class CannotPerformNestedParallelismException : Exception
+    {
+        public CannotPerformNestedParallelismException() { }
+
+        public CannotPerformNestedParallelismException(string msg) : base(msg) { }
+
+        public CannotPerformNestedParallelismException(string msg, Exception ex) : base(msg, ex) { }
+    }
 }

--- a/DotMP/Init.cs
+++ b/DotMP/Init.cs
@@ -81,6 +81,25 @@ namespace DotMP
         /// The schedule to be used in the parallel for loop.
         /// </summary>
         internal Schedule? schedule;
+        /// <summary>
+        /// Booleans per-thread to check if we're currently in a Parallel.For or Parallel.ForReduction<T>.
+        /// </summary>
+        volatile internal bool[] in_for;
+
+        public WorkShare()
+        {
+            this.threads = null;
+            this.threads_complete = 0;
+            this.ws_lock = null;
+            this.start = 0;
+            this.end = 0;
+            this.chunk_size = 0;
+            this.op = null;
+            this.reduction_list = null;
+            this.schedule = null;
+            this.in_for = new bool[0];
+            this.num_threads = 0;
+        }
 
         /// <summary>
         /// The constructor for a WorkShare object.
@@ -106,6 +125,9 @@ namespace DotMP
             this.op = op;
             this.reduction_list = new List<dynamic>();
             this.schedule = schedule;
+            this.in_for = new bool[num_threads];
+            for (int i = 0; i < num_threads; i++)
+                this.in_for[i] = false;
         }
     }
 
@@ -118,7 +140,7 @@ namespace DotMP
         /// <summary>
         /// The WorkShare struct being encapsulated by the Init static class.
         /// </summary>
-        internal static WorkShare ws;
+        internal static WorkShare ws = new WorkShare();
 
         /// <summary>
         /// Sets the local variable to the appropriate value based on the operation for parallel for reduction loops.

--- a/DotMP/Init.cs
+++ b/DotMP/Init.cs
@@ -86,6 +86,9 @@ namespace DotMP
         /// </summary>
         volatile internal bool[] in_for;
 
+        /// <summary>
+        /// Default constructor for WorkShare struct.
+        /// </summary>
         public WorkShare()
         {
             this.threads = null;

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -10,6 +10,7 @@ namespace DotMP
     /// The Runtime schedule simply fetches the schedule from the OMP_SCHEDULE environment variable.
     /// </summary>
     public enum Schedule { Static, Dynamic, Guided, Runtime };
+
     /// <summary>
     /// Contains all of the scheduling code for parallel for loops.
     /// </summary>

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -4,61 +4,17 @@ using System.Threading;
 namespace DotMP
 {
     /// <summary>
+    /// The different types of schedules for a parallel for loop.
+    /// The default schedule if none is specified is static.
+    /// Detailed explanations of each schedule can be found in the Iter class.
+    /// The Runtime schedule simply fetches the schedule from the OMP_SCHEDULE environment variable.
+    /// </summary>
+    public enum Schedule { Static, Dynamic, Guided, Runtime };
+    /// <summary>
     /// Contains all of the scheduling code for parallel for loops.
     /// </summary>
     internal static class Iter
     {
-        /// <summary>
-        /// Sets the local variable to the appropriate value based on the operation for parallel for reduction loops.
-        /// For addition and subtraction, the initial starting value is 0.
-        /// For multiplication, the initial starting value is 1.
-        /// For binary And, the initial starting value is -1.
-        /// For binary Or and Xor, the initial starting value is 0.
-        /// For boolean And, the initial starting value is true.
-        /// For boolean Or, the initial starting value is false.
-        /// For min, the initial starting value is int.MaxValue.
-        /// For max, the initial starting value is int.MinValue.
-        /// </summary>
-        /// <typeparam name="T">The type of the local variable.</typeparam>
-        /// <param name="local">The local variable to be set.</param>
-        /// <param name="op">The operation to be performed.</param>
-        private static void SetLocal<T>(ref T local, Operations? op)
-        {
-            switch (Init.ws.op)
-            {
-                case Operations.Add:
-                case Operations.Subtract:
-                    local = (T)Convert.ChangeType(0, typeof(T));
-                    break;
-                case Operations.Multiply:
-                    local = (T)Convert.ChangeType(1, typeof(T));
-                    break;
-                case Operations.BinaryAnd:
-                    local = (T)Convert.ChangeType(-1, typeof(T));
-                    break;
-                case Operations.BinaryOr:
-                    local = (T)Convert.ChangeType(0, typeof(T));
-                    break;
-                case Operations.BinaryXor:
-                    local = (T)Convert.ChangeType(0, typeof(T));
-                    break;
-                case Operations.BooleanAnd:
-                    local = (T)Convert.ChangeType(true, typeof(T));
-                    break;
-                case Operations.BooleanOr:
-                    local = (T)Convert.ChangeType(false, typeof(T));
-                    break;
-                case Operations.Min:
-                    local = (T)Convert.ChangeType(int.MaxValue, typeof(T));
-                    break;
-                case Operations.Max:
-                    local = (T)Convert.ChangeType(int.MinValue, typeof(T));
-                    break;
-                default:
-                    break;
-            }
-        }
-
         /// <summary>
         /// Starts and controls a parallel for loop with static scheduling.
         /// Static scheduling works as follows:
@@ -84,7 +40,7 @@ namespace DotMP
             int end = Init.ws.end;
 
             T local = default;
-            SetLocal(ref local, Init.ws.op);
+            Init.SetLocal(ref local);
 
             while (thr.curr_iter < end)
                 StaticNext(thr, tid, Init.ws.chunk_size, omp_fn, omp_fn_red, is_reduction, ref local);
@@ -152,7 +108,7 @@ namespace DotMP
             int end = Init.ws.end;
 
             T local = default;
-            SetLocal(ref local, Init.ws.op);
+            Init.SetLocal(ref local);
 
             while (Init.ws.start < end)
             {
@@ -228,7 +184,7 @@ namespace DotMP
             int end = Init.ws.end;
 
             T local = default;
-            SetLocal(ref local, Init.ws.op);
+            Init.SetLocal(ref local);
 
             while (Init.ws.start < end)
             {

--- a/DotMP/Lock.cs
+++ b/DotMP/Lock.cs
@@ -4,6 +4,8 @@ namespace DotMP
 {
     /// <summary>
     /// A lock that can be used in a parallel region.
+    /// Also contains static methods for locking.
+    /// Available methods are Set, Unset, and Test.
     /// </summary>
     public class Lock
     {
@@ -19,14 +21,7 @@ namespace DotMP
         {
             _lock = 0;
         }
-    }
 
-    /// <summary>
-    /// Static class that contains methods for locking.
-    /// Available methods are Set, Unset, and Test.
-    /// </summary>
-    public static class Locking
-    {
         /// <summary>
         /// Stalls the thread until the lock is set.
         /// </summary>

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -15,7 +15,7 @@ namespace DotMP
     /// <summary>
     /// The main class of DotMP.
     /// Contains all the main methods for parallelism.
-    /// For users, this is the main class you want to worry about, along with Locking, Lock, Shared, and Atomic
+    /// For users, this is the main class you want to worry about, along with Lock, Shared, and Atomic
     /// </summary>
     public static class Parallel
     {

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -20,13 +20,6 @@ namespace DotMP
     public static class Parallel
     {
         /// <summary>
-        /// The different types of schedules for a parallel for loop.
-        /// The default schedule if none is specified is static.
-        /// Detailed explanations of each schedule can be found in the Iter class.
-        /// The Runtime schedule simply fetches the schedule from the OMP_SCHEDULE environment variable.
-        /// </summary>
-        public enum Schedule { Static, Dynamic, Guided, Runtime };
-        /// <summary>
         /// The dictionary for critical regions.
         /// </summary>
         private static volatile Dictionary<int, (int, object)> critical_lock = new Dictionary<int, (int, object)>();
@@ -154,11 +147,7 @@ namespace DotMP
 
             Master(() =>
             {
-                Init.ws = new WorkShare((uint)GetNumThreads(), ForkedRegion.ws.threads);
-                Init.ws.start = start;
-                Init.ws.end = end;
-                Init.ws.chunk_size = chunk_size.Value;
-                Init.ws.schedule = schedule;
+                Init.ws = new WorkShare((uint)GetNumThreads(), ForkedRegion.ws.threads, start, end, num_threads, null, schedule);
             });
 
             Barrier();
@@ -209,12 +198,7 @@ namespace DotMP
 
             if (GetThreadNum() == 0)
             {
-                Init.ws = new WorkShare((uint)GetNumThreads(), ForkedRegion.ws.threads);
-                Init.ws.start = start;
-                Init.ws.end = end;
-                Init.ws.chunk_size = chunk_size.Value;
-                Init.ws.op = op;
-                Init.ws.schedule = schedule;
+                Init.ws = new WorkShare((uint)GetNumThreads(), ForkedRegion.ws.threads, start, end, chunk_size.Value, op, schedule);
                 Init.ws.reduction_list.Clear();
             }
 

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -136,6 +136,7 @@ namespace DotMP
         /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
         /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        /// <exception cref="CannotPerformNestedForException">Thrown if nested within another For or ForReduction<T>.</exception>
         public static void For(int start, int end, Action<int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
         {
             if (!ForkedRegion.in_parallel)
@@ -200,6 +201,7 @@ namespace DotMP
         /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
         /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        /// <exception cref="CannotPerformNestedForException">Thrown if nested within another For or ForReduction<T>.</exception>
         public static void ForReduction<T>(int start, int end, Operations op, ref T reduce_to, ActionRef<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
         {
             if (!ForkedRegion.in_parallel)

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -286,8 +286,12 @@ namespace DotMP
         /// </summary>
         /// <param name="action">The action to be performed in the parallel region.</param>
         /// <param name="num_threads">The number of threads to be used in the parallel region, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="CannotPerformNestedParallelismException">Thrown if ParallelRegion is called from within another ParallelRegion.</exception>
         public static void ParallelRegion(Action action, uint? num_threads = null)
         {
+            if (InParallel())
+                throw new CannotPerformNestedParallelismException();
+
             if (num_threads == null && Parallel.num_threads == 0)
                 num_threads = (uint)GetNumProcs();
             else

--- a/DotMP/Shared.cs
+++ b/DotMP/Shared.cs
@@ -163,7 +163,6 @@ namespace DotMP
         /// </summary>
         public new void Dispose()
         {
-            Parallel.Barrier();
             base.Dispose();
         }
 

--- a/DotMP/Shared.cs
+++ b/DotMP/Shared.cs
@@ -61,6 +61,7 @@ namespace DotMP
         /// <param name="disposing">Whether or not to dispose of the shared variable.</param>
         public virtual void Dispose(bool disposing)
         {
+            Parallel.Barrier();
             if (!Disposed)
             {
                 if (disposing)
@@ -162,6 +163,7 @@ namespace DotMP
         /// </summary>
         public new void Dispose()
         {
+            Parallel.Barrier();
             base.Dispose();
         }
 

--- a/DotMP/Shared.cs
+++ b/DotMP/Shared.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 
 namespace DotMP
 {
     /// <summary>
     /// A shared variable that can be used in a parallel region.
     /// This allows for a variable to be declared inside of a parallel region that is shared among all threads, which has some nice use cases.
-    /// The DotMP-parallelized Conjugate Gradient example shows this off fairly well inside of the SpMV function.
     /// </summary>
     /// <typeparam name="T">The type of the shared variable.</typeparam>
     public class Shared<T> : IDisposable
@@ -14,7 +14,7 @@ namespace DotMP
         /// <summary>
         /// The shared variables.
         /// </summary>
-        private static Dictionary<string, dynamic> shared = new Dictionary<string, dynamic>();
+        protected static Dictionary<string, dynamic> shared = new Dictionary<string, dynamic>();
 
         /// <summary>
         /// The name of the shared variable.
@@ -75,6 +75,15 @@ namespace DotMP
         }
 
         /// <summary>
+        /// Gets the value of the shared variable.
+        /// </summary>
+        /// <param name="shared">The shared variable to get the value from.</param>
+        public static implicit operator T(Shared<T> shared)
+        {
+            return shared.Get();
+        }
+
+        /// <summary>
         /// Sets the value of the shared variable.
         /// Is not thread-safe, so user must ensure thread safety.
         /// </summary>
@@ -91,6 +100,89 @@ namespace DotMP
         public T Get()
         {
             return shared[name];
+        }
+    }
+
+    /// <summary>
+    /// A specialization of Shared for items that can be indexed with square brackets.
+    /// The DotMP-parallelized Conjugate Gradient example shows this off fairly well inside of the SpMV function.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class SharedEnumerable<T> : Shared<IList<T>>
+    {
+        /// <summary>
+        /// Constructs a new shared variable with the given name and value.
+        /// </summary>
+        /// <param name="name">The name of the shared variable.</param>
+        /// <param name="value">The value of the shared variable.</param>
+        public SharedEnumerable(string name, IList<T> value) : base(name, value) { }
+
+        /// <summary>
+        /// Allows for indexing into the shared variable with square brackets.
+        /// </summary>
+        /// <param name="index">The index to fetch.</param>
+        /// <returns>The value at that index.</returns>
+        public T this[int index]
+        {
+            get => Get()[index];
+            set => Get()[index] = value;
+        }
+
+        /// <summary>
+        /// Allows for implicit conversion to an array.
+        /// </summary>
+        /// <param name="shared">A SharedEnumerable object.</param>
+        public static implicit operator T[](SharedEnumerable<T> shared)
+        {
+            return shared.GetArray();
+        }
+
+        /// <summary>
+        /// Allows for implicit conversion to a System.List<T>.
+        /// </summary>
+        /// <param name="shared">A SharedEnumerable object.</param>
+        public static implicit operator List<T>(SharedEnumerable<T> shared)
+        {
+            return shared.GetList();
+        }
+
+        /// <summary>
+        /// Clears the shared variable from memory.
+        /// Must be called from all threads in the parallel region.
+        /// Acts as a barrier.
+        /// </summary>
+        public new void Dispose()
+        {
+            base.Dispose();
+        }
+
+        /// <summary>
+        /// Gets the value of the shared variable as an IList<T>.
+        /// </summary>
+        /// <returns>The value of the shared variable as an IList<T>.</returns>
+        public new IList<T> Get()
+        {
+            return base.Get();
+        }
+
+        /// <summary>
+        /// Returns the value of the shared variable as an array.
+        /// Undefined behavior if the shared variable is not an array.
+        /// </summary>
+        /// <returns>The value of the shared variable as an array.</returns>
+        public T[] GetArray()
+        {
+            return (T[])Get();
+        }
+
+        /// <summary>
+        /// Returns the value of the shared variable as a System.List<T>.
+        /// Undefined behavior if the shared variable is not a System.List<T>.
+        /// </summary>
+        /// <returns>The value of the shared variable as a System.List<T>.</returns>
+        public List<T> GetList()
+        {
+            return (List<T>)Get();
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,19 @@ examples-cs:
 	$(DN) build -c $(BUILD) examples/CSParallel/ConjugateGradient
 	$(DN) build -c $(BUILD) examples/CSParallel/HeatTransfer
 	$(DN) build -c $(BUILD) examples/CSParallel/GEMM
+	$(DN) build -c $(BUILD) examples/CSParallel/KNN
 
 examples-dmp:
 	$(DN) build -c $(BUILD) examples/DotMP/ConjugateGradient
 	$(DN) build -c $(BUILD) examples/DotMP/HeatTransfer
 	$(DN) build -c $(BUILD) examples/DotMP/GEMM
+	$(DN) build -c $(BUILD) examples/DotMP/KNN
 
 examples-seq:
 	$(DN) build -c $(BUILD) examples/Serial/ConjugateGradient
 	$(DN) build -c $(BUILD) examples/Serial/HeatTransfer
 	$(DN) build -c $(BUILD) examples/Serial/GEMM
+	$(DN) build -c $(BUILD) examples/Serial/KNN
 
 tests:
 	$(DN) build -c $(BUILD) DotMP-Tests

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ BUILD=Release
 
 all: docs build tests examples
 
-examples: examples-cs examples-omp examples-seq
+examples: examples-cs examples-dmp examples-seq
 
 examples-cs:
 	$(DN) build -c $(BUILD) examples/CSParallel/ConjugateGradient
 	$(DN) build -c $(BUILD) examples/CSParallel/HeatTransfer
 	$(DN) build -c $(BUILD) examples/CSParallel/GEMM
 
-examples-omp:
+examples-dmp:
 	$(DN) build -c $(BUILD) examples/DotMP/ConjugateGradient
 	$(DN) build -c $(BUILD) examples/DotMP/HeatTransfer
 	$(DN) build -c $(BUILD) examples/DotMP/GEMM

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,33 @@
 DN=dotnet
+BUILD=Release
 
 all: docs build tests examples
 
 examples: examples-cs examples-omp examples-seq
 
 examples-cs:
-	$(DN) build -c Release examples/CSParallel/ConjugateGradient
-	$(DN) build -c Release examples/CSParallel/HeatTransfer
-	$(DN) build -c Release examples/CSParallel/GEMM
+	$(DN) build -c $(BUILD) examples/CSParallel/ConjugateGradient
+	$(DN) build -c $(BUILD) examples/CSParallel/HeatTransfer
+	$(DN) build -c $(BUILD) examples/CSParallel/GEMM
 
 examples-omp:
-	$(DN) build -c Release examples/DotMP/ConjugateGradient
-	$(DN) build -c Release examples/DotMP/HeatTransfer
-	$(DN) build -c Release examples/DotMP/GEMM
+	$(DN) build -c $(BUILD) examples/DotMP/ConjugateGradient
+	$(DN) build -c $(BUILD) examples/DotMP/HeatTransfer
+	$(DN) build -c $(BUILD) examples/DotMP/GEMM
 
 examples-seq:
-	$(DN) build -c Release examples/Serial/ConjugateGradient
-	$(DN) build -c Release examples/Serial/HeatTransfer
-	$(DN) build -c Release examples/Serial/GEMM
+	$(DN) build -c $(BUILD) examples/Serial/ConjugateGradient
+	$(DN) build -c $(BUILD) examples/Serial/HeatTransfer
+	$(DN) build -c $(BUILD) examples/Serial/GEMM
 
 tests:
-	$(DN) build -c Release DotMP-Tests
+	$(DN) build -c $(BUILD) DotMP-Tests
 
 test:
-	$(DN) test -c Release DotMP-Tests
+	$(DN) test -c $(BUILD) DotMP-Tests
 
 build:
-	$(DN) build -c Release DotMP
+	$(DN) build -c $(BUILD) DotMP
 
 docs:
 	doxygen

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ DotMP.Parallel.For(a, b, i => {
 });
 ```
 This function supports the `schedule` optional parameter, which sets the parallel scheduler to use.
-Permissible values are `DotMP.Parallel.Schedule.Static`, `DotMP.Parallel.Schedule.Dynamic`, `DotMP.Parallel.Schedule.Guided`, and `DotMP.Parallel.Schedule.Runtime`.
-The default value is `DotMP.Parallel.Schedule.Static`.
+Permissible values are `DotMP.Schedule.Static`, `DotMP.Schedule.Dynamic`, `DotMP.Schedule.Guided`, and `DotMP.Schedule.Runtime`.
+The default value is `DotMP.Schedule.Static`.
 
 This function supports the `chunk_size` optional parameter, which sets the chunk size for the scheduler to use.
 The default value is dependent on the scheduler and is not documented, as it may change from version to version.

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ They also allow an explicit `DotMP.Shared<T>.Get()` method to be used to retriev
 For setting, the `DotMP.Shared<T>.Set(T value)` method must be used.
 
 For indexable types, such as arrays, the `DotMP.SharedEnumerable<T>` class is provided.
-This class implements the `IDisposable` interface, and supports implicit casting to type `T[]` and `List<T>`.
+This class implements the `IDisposable` interface, and supports implicit casting to the containing type.
 This class also overloads the `[]` operator to allow for indexing.
 
 The following provides an example of a parallel vector initialization using `DotMP.SharedEnumerable<T>`:
@@ -363,7 +363,7 @@ static double[] InitVector()
     
     DotMP.Parallel.ParallelRegion(() =>
     {
-        using (DotMP.SharedEnumerable<double> vec = new DotMP.SharedEnumerable<double>("vec", new double[1024]))
+        using (var vec = DotMP.SharedEnumerable.Create("vec", new double[1024]))
         {
             DotMP.Parallel.For(0, 1024, i =>
             {
@@ -385,13 +385,14 @@ The `DotMP.Shared` and `DotMP.SharedEnumerable` classes supports the following m
 | DotMP.Shared.Dispose()                       | Disposes of a shared variable
 | DotMP.Shared.Set(T value)                    | Sets a shared variable to value `value`
 | DotMP.Shared.Get()                           | Gets a shared variable
-| DotMP.SharedEnumerable.SharedEnumerable(string name, IList<T> value) | Initializes a shared array with name `name` and starting value `value`
+| DotMP.SharedEnumerable.SharedEnumerable(string name, U value) | Initializes a shared array with name `name` and starting value `value`
 | DotMP.SharedEnumerable.Dispose()             | Disposes of a shared array
-| DotMP.SharedEnumerable.Get()                 | Gets a shared array as an `IList<T>`
-| DotMP.SharedEnumerable.GetArray()            | Gets a shared array as a `T[]`
-| DotMP.SharedEnumerable.GetList()             | Gets a shared array as a `List<T>`
+| DotMP.SharedEnumerable.Get()                 | Gets a shared enumerable as its containing type.
 
 The `DotMP.Shared` constructor and `Clear()` methods serve as implicit barriers, ensuring that all threads can access the memory before proceeding.
+
+`DotMP.Shared` provides a factory method for creating `DotMP.Shared` instances via the `DotMP.Shared.Create()` method.
+`DotMP.SharedEnumerable` provides factory methods for creating `DotMP.SharedEnumerable` instances containing either `T[]` or `List<T>` enumerables via the `DotMP.SharedEnumerable.Create()` methods.
 
 ## Supported Functions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This will build all of the examples, including the native C# parallelized, the D
 You can also individually build each of these classes of examples by running one or all of the following commands:
 ```sh
 make examples-cs
-make examples-omp
+make examples-dmp
 make examples-seq
 ```
 

--- a/README.md
+++ b/README.md
@@ -339,9 +339,9 @@ DotMP provides the following functions:
 
 | <omp.h> function     | DotMP function        | Comments
 -----------------------|----------------------------|---------
-| omp_set_lock(lock)   | DotMP.Locking.Set(lock)   | Halt the current thread until the lock is obtained
-| omp_unset_lock(lock) | DotMP.Locking.Unset(lock) | Free the current lock, making it available for other threads
-| omp_test_lock(lock)  | DotMP.Locking.Test(lock)  | Attempt to obtain a lock without blocking, returns true if locking is successful
+| omp_set_lock(lock)   | DotMP.Lock.Set(lock)   | Halt the current thread until the lock is obtained
+| omp_unset_lock(lock) | DotMP.Lock.Unset(lock) | Free the current lock, making it available for other threads
+| omp_test_lock(lock)  | DotMP.Lock.Test(lock)  | Attempt to obtain a lock without blocking, returns true if locking is successful
 
 ## Shared Memory
 

--- a/examples/CSParallel/KNN/KNN.csproj
+++ b/examples/CSParallel/KNN/KNN.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/CSParallel/KNN/KNN.sln
+++ b/examples/CSParallel/KNN/KNN.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KNN", "KNN.csproj", "{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AEB4E020-A8E5-48C3-A343-84A0FEBE91E2}
+	EndGlobalSection
+EndGlobal

--- a/examples/CSParallel/KNN/Program.cs
+++ b/examples/CSParallel/KNN/Program.cs
@@ -1,0 +1,185 @@
+﻿using DotMP;
+using System;
+using System.Threading.Tasks;
+
+class Point
+{
+    //coordinates of a 3D point
+    public double x { get; private set; }
+    public double y { get; private set; }
+    public double z { get; private set; }
+
+    //default constructor
+    public Point()
+    {
+        x = 0;
+        y = 0;
+        z = 0;
+    }
+
+    //constructor with parameters
+    public Point(double x, double y, double z)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}
+
+class Cluster
+{
+    //list of points in the cluster
+    private List<Point> points;
+
+    //default constructor
+    public Cluster()
+    {
+        points = new List<Point>();
+    }
+
+    //get the points in the cluster
+    public Point[] GetPoints()
+    {
+        //copy the points to an array
+        Point[] points = new Point[this.points.Count];
+        this.points.CopyTo(points);
+
+        //return the array
+        return points;
+    }
+
+    //add a point to the cluster
+    public void AddPoint(Point point)
+    {
+        points.Add(point);
+    }
+}
+
+static class KNN
+{
+    //generate a cluster of random points
+    public static Cluster GenerateCluster(int points)
+    {
+        //create a new cluster
+        Cluster cluster = new Cluster();
+        //create a random number generator
+        Random random = new Random();
+
+        //for each desired point
+        for (int i = 0; i < points; i++)
+        {
+            //add a new random point to the cluster
+            cluster.AddPoint(new Point(random.NextDouble(), random.NextDouble(), random.NextDouble()));
+        }
+
+        //return the cluster
+        return cluster;
+    }
+
+    //find the K-nearest neighbors of a point in a cluster
+    public static Point[] KNearestNeighbors(this Cluster cluster, Point point, int k)
+    {
+        //get the points in the cluster
+        Point[] points = cluster.GetPoints();
+        //create an array to store the K-nearest neighbors
+        Point[] nearestPoints = new Point[k];
+        //create an array to store the distances
+        double[] distances = new double[points.Length];
+
+        //for each point in the cluster
+        System.Threading.Tasks.Parallel.For(0, points.Length, i =>
+        {
+            //calculate the distance between the point and the given point
+            distances[i] = Math.Sqrt(Math.Pow(points[i].x - point.x, 2) + Math.Pow(points[i].y - point.y, 2) + Math.Pow(points[i].z - point.z, 2));
+        });
+
+        //sort the points based off of the distances
+        Array.Sort(distances, points);
+
+        //copy the K-nearest neighbors to the array
+        for (int i = 0; i < k; i++)
+        {
+            nearestPoints[i] = points[i];
+        }
+
+        //return the K-nearest neighbors
+        return nearestPoints;
+    }
+}
+
+class Driver
+{
+    //main function
+    public static void Main(string[] args)
+    {
+        //check for the correct number of arguments
+        if (args.Length < 6)
+        {
+            Console.WriteLine("Usage: dotnet run <number of points> <k> <x> <y> <z> <iters> [<output neighbors>]");
+            return;
+        }
+
+        //fetch all of the values from the command line
+        int numOfPoints = int.Parse(args[0]);
+        int k = int.Parse(args[1]);
+        Point point = new Point(double.Parse(args[2]), double.Parse(args[3]), double.Parse(args[4]));
+        int iters = int.Parse(args[5]);
+        bool output = (args.Length > 6) ? Convert.ToBoolean(args[6]) : false;
+
+        //create some default objects
+        Point[] points = new Point[0];
+        Cluster cluster;
+
+        double min = double.MaxValue;
+        double max = double.MinValue;
+        double avg = 0;
+
+        //generate a random cluster of points
+        cluster = KNN.GenerateCluster(numOfPoints);
+
+        //warmup
+        for (int i = 0; i < 5; i++)
+        {
+            //calculate the K-nearest neighbors
+            points = KNN.KNearestNeighbors(cluster, point, k);
+        }
+
+        //generate a random cluster of points
+        cluster = KNN.GenerateCluster(numOfPoints);
+
+        //do the simulation multiple times for testing
+        for (int i = 0; i < iters; i++)
+        {
+            //do the simulation
+            double tick = DotMP.Parallel.GetWTime();
+            points = KNN.KNearestNeighbors(cluster, point, k);
+            double tock = DotMP.Parallel.GetWTime();
+
+            //update min, max, avg
+            tock = tock - tick;
+            avg += tock;
+            min = Math.Min(min, tock);
+            max = Math.Max(max, tock);
+        }
+
+        avg /= iters;
+
+        //output the results if requested
+        if (output)
+        {
+            Console.WriteLine("Points:");
+            foreach (Point p in points)
+            {
+                Console.WriteLine($"({p.x}, {p.y}, {p.z})");
+            }
+        }
+
+        //output the results
+        Console.WriteLine("Min: {0}", min);
+        Console.WriteLine("Max: {0}", max);
+        Console.WriteLine("Avg: {0}", avg);
+
+        //exit the program
+        return;
+    }
+}

--- a/examples/DotMP/ConjugateGradient/Program.cs
+++ b/examples/DotMP/ConjugateGradient/Program.cs
@@ -99,26 +99,28 @@ static class ConjugateGradient
     public static double[] SpMV(CSRMatrix A, double[] x)
     {
         //create a shared array y which will be used to store the result of the matrix-vector product
-        DotMP.Shared<double[]> y = new DotMP.Shared<double[]>("y", new double[A.m]);
-
-        //compute the matrix-vector product in parallel
-        //we use guided scheduling to balance the irregular load between threads
-        DotMP.Parallel.For(0, A.m,
-            schedule: DotMP.Parallel.Schedule.Guided,
-            action: i =>
+        using (DotMP.SharedEnumerable<double> y = new DotMP.SharedEnumerable<double>("y", new double[A.m]))
         {
-            //compute the i-th element of the result
-            double sum = 0.0;
-            for (int j = A.rowPtr[i]; j < A.rowPtr[i + 1]; j++)
+            //compute the matrix-vector product in parallel
+            //we use guided scheduling to balance the irregular load between threads
+            DotMP.Parallel.For(0, A.m,
+                schedule: DotMP.Parallel.Schedule.Guided,
+                action: i =>
             {
-                //sum += A[i,j] * x[j]
-                sum += A.values[j] * x[A.colInd[j]];
-            }
-            //store the result in the shared array y
-            y.Get()[i] = sum;
-        });
+                //compute the i-th element of the result
+                double sum = 0.0;
+                for (int j = A.rowPtr[i]; j < A.rowPtr[i + 1]; j++)
+                {
+                    //sum += A[i,j] * x[j]
+                    sum += A.values[j] * x[A.colInd[j]];
+                }
+                //store the result in the shared array y
+                y[i] = sum;
+            });
 
-        return y.Get();
+            return y;
+        }
+
     }
 
     //compute the vector difference dest = x - y

--- a/examples/DotMP/ConjugateGradient/Program.cs
+++ b/examples/DotMP/ConjugateGradient/Program.cs
@@ -99,12 +99,12 @@ static class ConjugateGradient
     public static double[] SpMV(CSRMatrix A, double[] x)
     {
         //create a shared array y which will be used to store the result of the matrix-vector product
-        using (DotMP.SharedEnumerable<double> y = new DotMP.SharedEnumerable<double>("y", new double[A.m]))
+        using (var y = DotMP.SharedEnumerable.Create("y", new double[A.m]))
         {
             //compute the matrix-vector product in parallel
             //we use guided scheduling to balance the irregular load between threads
             DotMP.Parallel.For(0, A.m,
-                schedule: DotMP.Parallel.Schedule.Guided,
+                schedule: DotMP.Schedule.Guided,
                 action: i =>
             {
                 //compute the i-th element of the result

--- a/examples/DotMP/GEMM/Program.cs
+++ b/examples/DotMP/GEMM/Program.cs
@@ -12,7 +12,7 @@ static class GEMM
         int k = A[0].Length;
 
         //parallel for loop on the outermost loop
-        DotMP.Parallel.ParallelFor(0, m, schedule: DotMP.Parallel.Schedule.Dynamic, action: i =>
+        DotMP.Parallel.ParallelFor(0, m, schedule: DotMP.Schedule.Dynamic, action: i =>
         {
             //inner loop is serial
             for (int j = 0; j < n; j++)

--- a/examples/DotMP/HeatTransfer/Program.cs
+++ b/examples/DotMP/HeatTransfer/Program.cs
@@ -8,7 +8,7 @@ static class HeatTransfer
     private static void DoStep(double[,] grid, double[,] scratch, int dim)
     {
         //iterate over all cells not on the border
-        DotMP.Parallel.For(1, dim - 1, schedule: DotMP.Parallel.Schedule.Dynamic, action: i =>
+        DotMP.Parallel.For(1, dim - 1, schedule: DotMP.Schedule.Dynamic, action: i =>
         {
             for (int j = 1; j < dim - 1; j++)
             {
@@ -18,7 +18,7 @@ static class HeatTransfer
         });
 
         //copy the scratch array to the grid array
-        DotMP.Parallel.For(1, dim - 1, schedule: DotMP.Parallel.Schedule.Static, action: i =>
+        DotMP.Parallel.For(1, dim - 1, schedule: DotMP.Schedule.Static, action: i =>
         {
             for (int j = 1; j < dim - 1; j++)
             {

--- a/examples/DotMP/KNN/KNN.csproj
+++ b/examples/DotMP/KNN/KNN.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/DotMP/KNN/KNN.sln
+++ b/examples/DotMP/KNN/KNN.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KNN", "KNN.csproj", "{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AEB4E020-A8E5-48C3-A343-84A0FEBE91E2}
+	EndGlobalSection
+EndGlobal

--- a/examples/DotMP/KNN/Program.cs
+++ b/examples/DotMP/KNN/Program.cs
@@ -1,0 +1,184 @@
+﻿using DotMP;
+using System;
+
+class Point
+{
+    //coordinates of a 3D point
+    public double x { get; private set; }
+    public double y { get; private set; }
+    public double z { get; private set; }
+
+    //default constructor
+    public Point()
+    {
+        x = 0;
+        y = 0;
+        z = 0;
+    }
+
+    //constructor with parameters
+    public Point(double x, double y, double z)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}
+
+class Cluster
+{
+    //list of points in the cluster
+    private List<Point> points;
+
+    //default constructor
+    public Cluster()
+    {
+        points = new List<Point>();
+    }
+
+    //get the points in the cluster
+    public Point[] GetPoints()
+    {
+        //copy the points to an array
+        Point[] points = new Point[this.points.Count];
+        this.points.CopyTo(points);
+
+        //return the array
+        return points;
+    }
+
+    //add a point to the cluster
+    public void AddPoint(Point point)
+    {
+        points.Add(point);
+    }
+}
+
+static class KNN
+{
+    //generate a cluster of random points
+    public static Cluster GenerateCluster(int points)
+    {
+        //create a new cluster
+        Cluster cluster = new Cluster();
+        //create a random number generator
+        Random random = new Random();
+
+        //for each desired point
+        for (int i = 0; i < points; i++)
+        {
+            //add a new random point to the cluster
+            cluster.AddPoint(new Point(random.NextDouble(), random.NextDouble(), random.NextDouble()));
+        }
+
+        //return the cluster
+        return cluster;
+    }
+
+    //find the K-nearest neighbors of a point in a cluster
+    public static Point[] KNearestNeighbors(this Cluster cluster, Point point, int k)
+    {
+        //get the points in the cluster
+        Point[] points = cluster.GetPoints();
+        //create an array to store the K-nearest neighbors
+        Point[] nearestPoints = new Point[k];
+        //create an array to store the distances
+        double[] distances = new double[points.Length];
+
+        //for each point in the cluster
+        DotMP.Parallel.ParallelFor(0, points.Length, i =>
+        {
+            //calculate the distance between the point and the given point
+            distances[i] = Math.Sqrt(Math.Pow(points[i].x - point.x, 2) + Math.Pow(points[i].y - point.y, 2) + Math.Pow(points[i].z - point.z, 2));
+        });
+
+        //sort the points based off of the distances
+        Array.Sort(distances, points);
+
+        //copy the K-nearest neighbors to the array
+        for (int i = 0; i < k; i++)
+        {
+            nearestPoints[i] = points[i];
+        }
+
+        //return the K-nearest neighbors
+        return nearestPoints;
+    }
+}
+
+class Driver
+{
+    //main function
+    public static void Main(string[] args)
+    {
+        //check for the correct number of arguments
+        if (args.Length < 6)
+        {
+            Console.WriteLine("Usage: dotnet run <number of points> <k> <x> <y> <z> <iters> [<output neighbors>]");
+            return;
+        }
+
+        //fetch all of the values from the command line
+        int numOfPoints = int.Parse(args[0]);
+        int k = int.Parse(args[1]);
+        Point point = new Point(double.Parse(args[2]), double.Parse(args[3]), double.Parse(args[4]));
+        int iters = int.Parse(args[5]);
+        bool output = (args.Length > 6) ? Convert.ToBoolean(args[6]) : false;
+
+        //create some default objects
+        Point[] points = new Point[0];
+        Cluster cluster;
+
+        double min = double.MaxValue;
+        double max = double.MinValue;
+        double avg = 0;
+
+        //generate a random cluster of points
+        cluster = KNN.GenerateCluster(numOfPoints);
+
+        //warmup
+        for (int i = 0; i < 5; i++)
+        {
+            //calculate the K-nearest neighbors
+            points = KNN.KNearestNeighbors(cluster, point, k);
+        }
+
+        //generate a random cluster of points
+        cluster = KNN.GenerateCluster(numOfPoints);
+
+        //do the simulation multiple times for testing
+        for (int i = 0; i < iters; i++)
+        {
+            //do the simulation
+            double tick = DotMP.Parallel.GetWTime();
+            points = KNN.KNearestNeighbors(cluster, point, k);
+            double tock = DotMP.Parallel.GetWTime();
+
+            //update min, max, avg
+            tock = tock - tick;
+            avg += tock;
+            min = Math.Min(min, tock);
+            max = Math.Max(max, tock);
+        }
+
+        avg /= iters;
+
+        //output the results if requested
+        if (output)
+        {
+            Console.WriteLine("Points:");
+            foreach (Point p in points)
+            {
+                Console.WriteLine($"({p.x}, {p.y}, {p.z})");
+            }
+        }
+
+        //output the results
+        Console.WriteLine("Min: {0}", min);
+        Console.WriteLine("Max: {0}", max);
+        Console.WriteLine("Avg: {0}", avg);
+
+        //exit the program
+        return;
+    }
+}

--- a/examples/Serial/KNN/KNN.csproj
+++ b/examples/Serial/KNN/KNN.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\DotMP\DotMP.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/Serial/KNN/KNN.sln
+++ b/examples/Serial/KNN/KNN.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KNN", "KNN.csproj", "{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0260DB7F-8C67-42A5-A4B6-66A3EC0E95DB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AEB4E020-A8E5-48C3-A343-84A0FEBE91E2}
+	EndGlobalSection
+EndGlobal

--- a/examples/Serial/KNN/Program.cs
+++ b/examples/Serial/KNN/Program.cs
@@ -1,0 +1,184 @@
+﻿using DotMP;
+using System;
+
+class Point
+{
+    //coordinates of a 3D point
+    public double x { get; private set; }
+    public double y { get; private set; }
+    public double z { get; private set; }
+
+    //default constructor
+    public Point()
+    {
+        x = 0;
+        y = 0;
+        z = 0;
+    }
+
+    //constructor with parameters
+    public Point(double x, double y, double z)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}
+
+class Cluster
+{
+    //list of points in the cluster
+    private List<Point> points;
+
+    //default constructor
+    public Cluster()
+    {
+        points = new List<Point>();
+    }
+
+    //get the points in the cluster
+    public Point[] GetPoints()
+    {
+        //copy the points to an array
+        Point[] points = new Point[this.points.Count];
+        this.points.CopyTo(points);
+
+        //return the array
+        return points;
+    }
+
+    //add a point to the cluster
+    public void AddPoint(Point point)
+    {
+        points.Add(point);
+    }
+}
+
+static class KNN
+{
+    //generate a cluster of random points
+    public static Cluster GenerateCluster(int points)
+    {
+        //create a new cluster
+        Cluster cluster = new Cluster();
+        //create a random number generator
+        Random random = new Random();
+
+        //for each desired point
+        for (int i = 0; i < points; i++)
+        {
+            //add a new random point to the cluster
+            cluster.AddPoint(new Point(random.NextDouble(), random.NextDouble(), random.NextDouble()));
+        }
+
+        //return the cluster
+        return cluster;
+    }
+
+    //find the K-nearest neighbors of a point in a cluster
+    public static Point[] KNearestNeighbors(this Cluster cluster, Point point, int k)
+    {
+        //get the points in the cluster
+        Point[] points = cluster.GetPoints();
+        //create an array to store the K-nearest neighbors
+        Point[] nearestPoints = new Point[k];
+        //create an array to store the distances
+        double[] distances = new double[points.Length];
+
+        //for each point in the cluster
+        for (int i = 0; i < points.Length; i++)
+        {
+            //calculate the distance between the point and the given point
+            distances[i] = Math.Sqrt(Math.Pow(points[i].x - point.x, 2) + Math.Pow(points[i].y - point.y, 2) + Math.Pow(points[i].z - point.z, 2));
+        }
+
+        //sort the points based off of the distances
+        Array.Sort(distances, points);
+
+        //copy the K-nearest neighbors to the array
+        for (int i = 0; i < k; i++)
+        {
+            nearestPoints[i] = points[i];
+        }
+
+        //return the K-nearest neighbors
+        return nearestPoints;
+    }
+}
+
+class Driver
+{
+    //main function
+    public static void Main(string[] args)
+    {
+        //check for the correct number of arguments
+        if (args.Length < 6)
+        {
+            Console.WriteLine("Usage: dotnet run <number of points> <k> <x> <y> <z> <iters> [<output neighbors>]");
+            return;
+        }
+
+        //fetch all of the values from the command line
+        int numOfPoints = int.Parse(args[0]);
+        int k = int.Parse(args[1]);
+        Point point = new Point(double.Parse(args[2]), double.Parse(args[3]), double.Parse(args[4]));
+        int iters = int.Parse(args[5]);
+        bool output = (args.Length > 6) ? Convert.ToBoolean(args[6]) : false;
+
+        //create some default objects
+        Point[] points = new Point[0];
+        Cluster cluster;
+
+        double min = double.MaxValue;
+        double max = double.MinValue;
+        double avg = 0;
+
+        //generate a random cluster of points
+        cluster = KNN.GenerateCluster(numOfPoints);
+
+        //warmup
+        for (int i = 0; i < 5; i++)
+        {
+            //calculate the K-nearest neighbors
+            points = KNN.KNearestNeighbors(cluster, point, k);
+        }
+
+        //generate a random cluster of points
+        cluster = KNN.GenerateCluster(numOfPoints);
+
+        //do the simulation multiple times for testing
+        for (int i = 0; i < iters; i++)
+        {
+            //do the simulation
+            double tick = DotMP.Parallel.GetWTime();
+            points = KNN.KNearestNeighbors(cluster, point, k);
+            double tock = DotMP.Parallel.GetWTime();
+
+            //update min, max, avg
+            tock = tock - tick;
+            avg += tock;
+            min = Math.Min(min, tock);
+            max = Math.Max(max, tock);
+        }
+
+        avg /= iters;
+
+        //output the results if requested
+        if (output)
+        {
+            Console.WriteLine("Points:");
+            foreach (Point p in points)
+            {
+                Console.WriteLine($"({p.x}, {p.y}, {p.z})");
+            }
+        }
+
+        //output the results
+        Console.WriteLine("Min: {0}", min);
+        Console.WriteLine("Max: {0}", max);
+        Console.WriteLine("Avg: {0}", avg);
+
+        //exit the program
+        return;
+    }
+}


### PR DESCRIPTION
Here is a list of everything changed in this PR:

- removed the `Locking` class and merged everything into `DotMP.Lock`
- `Shared<T>` now implements `IDisposable`
- created `SharedEnumerable<T,U>` which overloads the `[]` operator for easy use of shared enumerables
- created factory methods for both `Shared` and `SharedEnumerable` objects
- nested parallelism now triggers an exception
- nested for or for-reduction loops now trigger exceptions
- added a K-nearest-neighbors example
- moved the `Schedule` enum out of the `Parallel` class to reside directly within the `DotMP` namespace
- updated documentation to reflect all of these changes