### PR TITLE
Updated Lock API (Issue #43)

### DIFF
--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1,11 +1,11 @@
-﻿using DotMP;
-using FluentAssertions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using DotMP;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using DotMP;
@@ -502,22 +501,22 @@ namespace DotMPTests
 
             DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                DotMP.Lock.Set(l);
+                l.Set();
                 Thread.Sleep(100);
-                DotMP.Lock.Unset(l);
+                l.Unset();
             });
 
             double elapsed = DotMP.Parallel.GetWTime() - time;
             elapsed.Should().BeGreaterThan(1.6);
 
-            DotMP.Lock.Test(l).Should().BeTrue();
-            DotMP.Lock.Test(l).Should().BeFalse();
-            DotMP.Lock.Test(l).Should().BeFalse();
-            DotMP.Lock.Unset(l);
-            DotMP.Lock.Test(l).Should().BeTrue();
-            DotMP.Lock.Test(l).Should().BeFalse();
-            DotMP.Lock.Test(l).Should().BeFalse();
-            DotMP.Lock.Unset(l);
+            l.Test().Should().BeTrue();
+            l.Test().Should().BeFalse();
+            l.Test().Should().BeFalse();
+            l.Unset();
+            l.Test().Should().BeTrue();
+            l.Test().Should().BeFalse();
+            l.Test().Should().BeFalse();
+            l.Unset();
         }
 
         /// <summary>

--- a/DotMP/Lock.cs
+++ b/DotMP/Lock.cs
@@ -4,7 +4,7 @@ namespace DotMP
 {
     /// <summary>
     /// A lock that can be used in a parallel region.
-    /// Also contains static methods for locking.
+    /// Also contains instance methods for locking.
     /// Available methods are Set, Unset, and Test.
     /// </summary>
     public sealed class Lock
@@ -25,30 +25,27 @@ namespace DotMP
         /// <summary>
         /// Stalls the thread until the lock is set.
         /// </summary>
-        /// <param name="lck">The lock to wait for.</param>
-        public static void Set(Lock lck)
+        public void Set()
         {
-            while (Interlocked.CompareExchange(ref lck._lock, 1, 0) == 1) ;
+            while (Interlocked.CompareExchange(ref this._lock, 1, 0) == 1) ;
         }
 
         /// <summary>
         /// Unsets the lock.
         /// </summary>
-        /// <param name="lck">The lock to unset.</param>
-        public static void Unset(Lock lck)
+        public void Unset()
         {
-            Interlocked.Exchange(ref lck._lock, 0);
+            Interlocked.Exchange(ref this._lock, 0);
         }
 
         /// <summary>
         /// Attempts to set the lock.
         /// Does not stall the thread.
         /// </summary>
-        /// <param name="lck">The lock to attempt to set.</param>
         /// <returns>True if the lock was set, false otherwise.</returns>
-        public static bool Test(Lock lck)
+        public bool Test()
         {
-            return Interlocked.CompareExchange(ref lck._lock, 1, 0) == 0;
+            return Interlocked.CompareExchange(ref this._lock, 1, 0) == 0;
         }
     }
 }


### PR DESCRIPTION
I have refactored the Lock.cs Class to access internal locking by instance, rather than in a static way. I have also updated the method’s documentation and taken a look into the README, but didn’t seem to me that it needed any changes.


Testing method Locks_work was also refactored to reflect new Lock API functionality.
All tests passed (.NET 6.0 and .NET 7.0).
<img width="950" alt="image" src="https://github.com/computablee/DotMP/assets/74781187/c4514691-ac55-455c-b72c-498bdc0d179c">
