### PR TITLE
Add test for `Parallel.MasterTaskloop`

### DIFF
--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -543,7 +543,6 @@ namespace DotMPTests
             total_uint.Should().Be(1023);
 
             byte total_byte = 0;
-            Console.WriteLine("here");
 
             DotMP.Parallel.ParallelForReduction(0, 256, DotMP.Operations.BinaryXor, ref total_byte, num_threads: 8, chunk_size: 1, schedule: DotMP.Schedule.Static, action: (ref byte total, int i) =>
             {

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1141,9 +1141,12 @@ namespace DotMPTests
         {
             float[] z = new float[x.Length];
 
-            DotMP.Parallel.ParallelMasterTaskloop(0, x.Length, grainsize: grainsize, num_threads: 6, action: i =>
+            DotMP.Parallel.ParallelRegion(num_threads: 6, action: () =>
             {
-                z[i] += a * x[i] + y[i];
+                DotMP.Parallel.MasterTaskloop(0, x.Length, grainsize: grainsize, action: i =>
+                {
+                    z[i] += a * x[i] + y[i];
+                });
             });
 
             return z;


### PR DESCRIPTION
This PR simply modifies the implementation of `saxpy_parallelregion_for_taskloop` to call `Parallel.MasterTaskloop` instead of `Parallel.ParallelMasterTaskloop`. This increases code coverage because `ParallelMasterTaskloop` is already tested elsewhere in the code.