### PR TITLE
Features

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,18 @@ updates:
       - "nuget"
     commit-message:
       prefix: "nuget"
+
+  - package-ecosystem: "nuget"
+    directory: "./benchmarks/HeatTransfer/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependency"
+      - "nuget"
+    commit-message:
+      prefix: "nuget"
+    groups:
+      bench:
+        patterns:
+          - "BenchmarkDotNet"
+          - "BenchmarkDotNet.*"

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading;
 using DotMP;
 using FluentAssertions;
@@ -165,6 +166,23 @@ namespace DotMPTests
                         iters_hit[i, j].Should().Be(1);
                     else
                         iters_hit[i, j].Should().Be(0);
+
+            iters_hit = null;
+
+            int[,,] iters_hit_3 = new int[128, 128, 64];
+
+            DotMP.Parallel.ParallelForCollapse((35, 64), (16, 100), (10, 62), num_threads: 8, chunk_size: 3, schedule: Schedule.Dynamic, action: (i, j, k) =>
+            {
+                DotMP.Atomic.Inc(ref iters_hit_3[i, j, k]);
+            });
+
+            for (int i = 0; i < 128; i++)
+                for (int j = 0; j < 128; j++)
+                    for (int k = 0; k < 64; k++)
+                        if (i >= 35 && i < 64 && j >= 16 && j < 100 && k >= 10 && k < 62)
+                            iters_hit_3[i, j, k].Should().Be(1);
+                        else
+                            iters_hit_3[i, j, k].Should().Be(0);
         }
 
         /// <summary>

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -147,6 +147,27 @@ namespace DotMPTests
         }
 
         /// <summary>
+        /// Tests to make sure that DotMP.Parallel.ForCollapse produces correct results.
+        /// </summary>
+        [Fact]
+        public void Collapse_works()
+        {
+            int[,] iters_hit = new int[1024, 1024];
+
+            DotMP.Parallel.ParallelForCollapse((256, 512), (512, 768), num_threads: 8, chunk_size: 7, schedule: Schedule.Static, action: (i, j) =>
+            {
+                DotMP.Atomic.Inc(ref iters_hit[i, j]);
+            });
+
+            for (int i = 0; i < 1024; i++)
+                for (int j = 0; j < 1024; j++)
+                    if (i >= 256 && i < 512 && j >= 512 && j < 768)
+                        iters_hit[i, j].Should().Be(1);
+                    else
+                        iters_hit[i, j].Should().Be(0);
+        }
+
+        /// <summary>
         /// Tests to make sure that taskloops produce correct results.
         /// </summary>
         [Fact]

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -154,14 +154,14 @@ namespace DotMPTests
         {
             int[,] iters_hit = new int[1024, 1024];
 
-            DotMP.Parallel.ParallelForCollapse((256, 512), (512, 768), num_threads: 8, chunk_size: 7, schedule: Schedule.Static, action: (i, j) =>
+            DotMP.Parallel.ParallelForCollapse((256, 512), (512, 600), num_threads: 8, chunk_size: 7, schedule: Schedule.Static, action: (i, j) =>
             {
                 DotMP.Atomic.Inc(ref iters_hit[i, j]);
             });
 
             for (int i = 0; i < 1024; i++)
                 for (int j = 0; j < 1024; j++)
-                    if (i >= 256 && i < 512 && j >= 512 && j < 768)
+                    if (i >= 256 && i < 512 && j >= 512 && j < 600)
                         iters_hit[i, j].Should().Be(1);
                     else
                         iters_hit[i, j].Should().Be(0);

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -73,10 +73,9 @@ namespace DotMP
         /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thread_id">The thread ID.</param>
-        /// <param name="omp_fn">The function to be executed.</param>
-        /// <param name="omp_fn_red">The function to be executed for reductions.</param>
+        /// <param name="forAction">The function to be executed.</param>
         /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
-        internal static void StaticLoop<T>(WorkShare ws, int thread_id, Action<int> omp_fn, ActionRef<T> omp_fn_red, bool is_reduction)
+        internal static void StaticLoop<T>(WorkShare ws, int thread_id, ForAction<T> forAction, bool is_reduction)
         {
             int tid = thread_id;
             Thr thr = ws.thread;
@@ -88,7 +87,7 @@ namespace DotMP
             ws.SetLocal(ref local);
 
             while (thr.curr_iter < end)
-                StaticNext(ws, thr, ws.chunk_size, omp_fn, omp_fn_red, is_reduction, ref local);
+                StaticNext(ws, thr, ws.chunk_size, forAction, is_reduction, ref local);
 
             ws.AddReductionValue(local);
         }
@@ -101,16 +100,15 @@ namespace DotMP
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thr">The Thr object for the current thread.</param>
         /// <param name="chunk_size">The chunk size.</param>
-        /// <param name="omp_fn">The function to be executed.</param>
-        /// <param name="omp_fn_red">The function to be executed for reductions.</param>
+        /// <param name="forAction">The function to be executed.</param>
         /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="local">The local variable for reductions.</param>
-        private static void StaticNext<T>(WorkShare ws, Thr thr, uint chunk_size, Action<int> omp_fn, ActionRef<T> omp_fn_red, bool is_reduction, ref T local)
+        private static void StaticNext<T>(WorkShare ws, Thr thr, uint chunk_size, ForAction<T> forAction, bool is_reduction, ref T local)
         {
             int start = thr.curr_iter;
             int end = (int)Math.Min(thr.curr_iter + chunk_size, ws.end);
 
-            InnerLoop(ref thr.working_iter, ref local, omp_fn, omp_fn_red, start, end, is_reduction);
+            forAction.PerformLoop(ref thr.working_iter, start, end, ref local);
 
             thr.curr_iter += (int)(ws.num_threads * chunk_size);
         }
@@ -120,11 +118,10 @@ namespace DotMP
         /// </summary>
         /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
         /// <param name="ws">The WorkShare object for state.</param>
-        /// <param name="omp_fn">The function to be executed.</param>
-        /// <param name="omp_fn_red">The function to be executed for reductions.</param>
+        /// <param name="forAction">The function to be executed.</param>
         /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="schedule">The schedule to use.</param>
-        internal static void LoadBalancingLoop<T>(WorkShare ws, Action<int> omp_fn, ActionRef<T> omp_fn_red, bool is_reduction, Schedule schedule)
+        internal static void LoadBalancingLoop<T>(WorkShare ws, ForAction<T> forAction, bool is_reduction, Schedule schedule)
         {
             Thr thr = ws.thread;
             int end = ws.end;
@@ -134,11 +131,11 @@ namespace DotMP
 
             if (schedule == Schedule.Guided) while (ws.start < end)
                 {
-                    GuidedNext(ws, thr, omp_fn, omp_fn_red, is_reduction, ref local);
+                    GuidedNext(ws, thr, forAction, is_reduction, ref local);
                 }
             else if (schedule == Schedule.Dynamic) while (ws.start < end)
                 {
-                    DynamicNext(ws, thr, omp_fn, omp_fn_red, is_reduction, ref local);
+                    DynamicNext(ws, thr, forAction, is_reduction, ref local);
                 }
 
             ws.AddReductionValue(local);
@@ -151,11 +148,10 @@ namespace DotMP
         /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thr">The Thr object for the current thread.</param>
-        /// <param name="omp_fn">The function to be executed.</param>
-        /// <param name="omp_fn_red">The function to be executed for reductions.</param>
+        /// <param name="forAction">The function to be executed.</param>
         /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="local">The local variable for reductions.</param>
-        private static void DynamicNext<T>(WorkShare ws, Thr thr, Action<int> omp_fn, ActionRef<T> omp_fn_red, bool is_reduction, ref T local)
+        private static void DynamicNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, bool is_reduction, ref T local)
         {
             int chunk_start;
 
@@ -167,7 +163,7 @@ namespace DotMP
 
             int chunk_end = (int)Math.Min(chunk_start + ws.chunk_size, ws.end);
 
-            InnerLoop(ref thr.working_iter, ref local, omp_fn, omp_fn_red, chunk_start, chunk_end, is_reduction);
+            forAction.PerformLoop(ref thr.working_iter, chunk_start, chunk_end, ref local);
         }
 
         /// <summary>
@@ -177,11 +173,10 @@ namespace DotMP
         /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thr">The Thr object for the current thread.</param>
-        /// <param name="omp_fn">The function to be executed.</param>
-        /// <param name="omp_fn_red">The function to be executed for reductions.</param>
+        /// <param name="forAction">The function to be executed.</param>
         /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="local">The local variable for reductions.</param>
-        private static void GuidedNext<T>(WorkShare ws, Thr thr, Action<int> omp_fn, ActionRef<T> omp_fn_red, bool is_reduction, ref T local)
+        private static void GuidedNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, bool is_reduction, ref T local)
         {
             int chunk_start, chunk_size;
 
@@ -195,30 +190,7 @@ namespace DotMP
 
             int chunk_end = Math.Min(chunk_start + chunk_size, ws.end);
 
-            InnerLoop(ref thr.working_iter, ref local, omp_fn, omp_fn_red, chunk_start, chunk_end, is_reduction);
-        }
-
-        /// <summary>
-        /// Performs the innermost loop to execute a chunk.
-        /// </summary>
-        /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
-        /// <param name="curr_iter">A reference to the thread's current working iteration.</param>
-        /// <param name="local">The local variable used for reductions.</param>
-        /// <param name="omp_fn">The function to be executed.</param>
-        /// <param name="omp_fn_red">The function to be executed for reductions.</param>
-        /// <param name="start">The start of the current chunk, inclusive.</param>
-        /// <param name="end">The end of the current chunk, exclusive.</param>
-        /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
-        private static void InnerLoop<T>(ref int curr_iter, ref T local, Action<int> omp_fn, ActionRef<T> omp_fn_red, int start, int end, bool is_reduction)
-        {
-            if (!is_reduction) for (curr_iter = start; curr_iter < end; curr_iter++)
-                {
-                    omp_fn(curr_iter);
-                }
-            else for (curr_iter = start; curr_iter < end; curr_iter++)
-                {
-                    omp_fn_red(ref local, curr_iter);
-                }
+            forAction.PerformLoop(ref thr.working_iter, chunk_start, chunk_end, ref local);
         }
     }
 }

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -74,8 +74,7 @@ namespace DotMP
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thread_id">The thread ID.</param>
         /// <param name="forAction">The function to be executed.</param>
-        /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
-        internal static void StaticLoop<T>(WorkShare ws, int thread_id, ForAction<T> forAction, bool is_reduction)
+        internal static void StaticLoop<T>(WorkShare ws, int thread_id, ForAction<T> forAction)
         {
             int tid = thread_id;
             Thr thr = ws.thread;
@@ -87,7 +86,7 @@ namespace DotMP
             ws.SetLocal(ref local);
 
             while (thr.curr_iter < end)
-                StaticNext(ws, thr, ws.chunk_size, forAction, is_reduction, ref local);
+                StaticNext(ws, thr, ws.chunk_size, forAction, ref local);
 
             ws.AddReductionValue(local);
         }
@@ -101,9 +100,8 @@ namespace DotMP
         /// <param name="thr">The Thr object for the current thread.</param>
         /// <param name="chunk_size">The chunk size.</param>
         /// <param name="forAction">The function to be executed.</param>
-        /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="local">The local variable for reductions.</param>
-        private static void StaticNext<T>(WorkShare ws, Thr thr, uint chunk_size, ForAction<T> forAction, bool is_reduction, ref T local)
+        private static void StaticNext<T>(WorkShare ws, Thr thr, uint chunk_size, ForAction<T> forAction, ref T local)
         {
             int start = thr.curr_iter;
             int end = (int)Math.Min(thr.curr_iter + chunk_size, ws.end);
@@ -119,9 +117,8 @@ namespace DotMP
         /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="forAction">The function to be executed.</param>
-        /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="schedule">The schedule to use.</param>
-        internal static void LoadBalancingLoop<T>(WorkShare ws, ForAction<T> forAction, bool is_reduction, Schedule schedule)
+        internal static void LoadBalancingLoop<T>(WorkShare ws, ForAction<T> forAction, Schedule schedule)
         {
             Thr thr = ws.thread;
             int end = ws.end;
@@ -131,11 +128,11 @@ namespace DotMP
 
             if (schedule == Schedule.Guided) while (ws.start < end)
                 {
-                    GuidedNext(ws, thr, forAction, is_reduction, ref local);
+                    GuidedNext(ws, thr, forAction, ref local);
                 }
             else if (schedule == Schedule.Dynamic) while (ws.start < end)
                 {
-                    DynamicNext(ws, thr, forAction, is_reduction, ref local);
+                    DynamicNext(ws, thr, forAction, ref local);
                 }
 
             ws.AddReductionValue(local);
@@ -149,9 +146,8 @@ namespace DotMP
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thr">The Thr object for the current thread.</param>
         /// <param name="forAction">The function to be executed.</param>
-        /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="local">The local variable for reductions.</param>
-        private static void DynamicNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, bool is_reduction, ref T local)
+        private static void DynamicNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, ref T local)
         {
             int chunk_start;
 
@@ -174,9 +170,8 @@ namespace DotMP
         /// <param name="ws">The WorkShare object for state.</param>
         /// <param name="thr">The Thr object for the current thread.</param>
         /// <param name="forAction">The function to be executed.</param>
-        /// <param name="is_reduction">Whether or not the loop is a reduction loop.</param>
         /// <param name="local">The local variable for reductions.</param>
-        private static void GuidedNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, bool is_reduction, ref T local)
+        private static void GuidedNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, ref T local)
         {
             int chunk_start, chunk_size;
 

--- a/DotMP/Lock.cs
+++ b/DotMP/Lock.cs
@@ -12,7 +12,7 @@ namespace DotMP
         /// <summary>
         /// The int acting as the lock.
         /// </summary>
-        volatile internal int _lock;
+        volatile private int _lock;
 
         /// <summary>
         /// Constructs a new lock.

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -170,7 +170,7 @@ namespace DotMP
         /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
         /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
-        public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Action<int, int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange, thirdRange });
 
@@ -197,7 +197,7 @@ namespace DotMP
         /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
         /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
-        public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Action<int, int, int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange, thirdRange, fourthRange });
 
@@ -222,7 +222,7 @@ namespace DotMP
         /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
         /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
-        public static void ForCollapse((int, int)[] ranges, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        public static void ForCollapse((int, int)[] ranges, Action<int[]> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, ranges);
 
@@ -465,6 +465,62 @@ namespace DotMP
             ParallelRegion(num_threads: num_threads, action: () =>
             {
                 ForCollapse(firstRange, secondRange, action, schedule, chunk_size);
+            });
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Action<int, int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForCollapse(firstRange, secondRange, thirdRange, action, schedule, chunk_size);
+            });
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="fourthRange">A tuple representing the start and end of the fourth for loop.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Action<int, int, int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForCollapse(firstRange, secondRange, thirdRange, fourthRange, action, schedule, chunk_size);
+            });
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="ranges">A tuple representing the start and end of each of the for loops.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForCollapse((int, int)[] ranges, Action<int[]> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForCollapse(ranges, action, schedule, chunk_size);
             });
         }
 

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -305,6 +305,129 @@ namespace DotMP
         }
 
         /// <summary>
+        /// Creates a collapsed reduction for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// 
+        /// Unlike Parallel.ForCollapse, this method permits a reduction parameter.
+        /// </summary>
+        /// <typeparam name="T">The type of the reduction.</typeparam>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, Operations op, ref T reduce_to, ActionRef2<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<T> forAction = new ForAction<T>(action, new (int, int)[] { firstRange, secondRange });
+
+            ForReduction(0,
+                (firstRange.Item2 - firstRange.Item1) *
+                (secondRange.Item2 - secondRange.Item1),
+                op, ref reduce_to, forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
+        /// Creates a collapsed reduction for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// 
+        /// Unlike Parallel.ForCollapse, this method permits a reduction parameter.
+        /// </summary>
+        /// <typeparam name="T">The type of the reduction.</typeparam>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Operations op, ref T reduce_to, ActionRef3<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<T> forAction = new ForAction<T>(action, new (int, int)[] { firstRange, secondRange, thirdRange });
+
+            ForReduction(0,
+                (firstRange.Item2 - firstRange.Item1) *
+                (secondRange.Item2 - secondRange.Item1) *
+                (thirdRange.Item2 - thirdRange.Item1),
+                op, ref reduce_to, forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
+        /// Creates a collapsed reduction for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// 
+        /// Unlike Parallel.ForCollapse, this method permits a reduction parameter.
+        /// </summary>
+        /// <typeparam name="T">The type of the reduction.</typeparam>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="fourthRange">A tuple representing the start and end of the fourth for loop.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Operations op, ref T reduce_to, ActionRef4<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<T> forAction = new ForAction<T>(action, new (int, int)[] { firstRange, secondRange, thirdRange, fourthRange });
+
+            ForReduction(0,
+                (firstRange.Item2 - firstRange.Item1) *
+                (secondRange.Item2 - secondRange.Item1) *
+                (thirdRange.Item2 - thirdRange.Item1) *
+                (fourthRange.Item2 - fourthRange.Item1),
+                op, ref reduce_to, forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
+        /// Creates a collapsed reduction for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// 
+        /// Unlike Parallel.ForCollapse, this method permits a reduction parameter.
+        /// </summary>
+        /// <typeparam name="T">The type of the reduction.</typeparam>
+        /// <param name="ranges">A tuple representing the start and end of each of the for loops.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForReductionCollapse<T>((int, int)[] ranges, Operations op, ref T reduce_to, ActionRefN<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<T> forAction = new ForAction<T>(action, ranges);
+
+            int total_iters = 1;
+
+            foreach ((int i, int j) in ranges)
+                total_iters *= j - i;
+
+            ForReduction(0, total_iters, op, ref reduce_to, forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
         /// Internal handler for ForReduction.
         /// </summary>
         /// <param name="start">The start of the loop, inclusive.</param>
@@ -434,7 +557,7 @@ namespace DotMP
 
         /// <summary>
         /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
-        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop.
         /// </summary>
         /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
         /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
@@ -452,7 +575,7 @@ namespace DotMP
 
         /// <summary>
         /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
-        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop.
         /// </summary>
         /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
         /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
@@ -471,7 +594,7 @@ namespace DotMP
 
         /// <summary>
         /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
-        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop.
         /// </summary>
         /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
         /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
@@ -491,7 +614,7 @@ namespace DotMP
 
         /// <summary>
         /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
-        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop.
         /// </summary>
         /// <param name="ranges">A tuple representing the start and end of each of the for loops.</param>
         /// <param name="action">The action to be performed in the loop.</param>
@@ -504,6 +627,104 @@ namespace DotMP
             {
                 ForCollapse(ranges, action, schedule, chunk_size);
             });
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed reduction for loop. Contains all of the parameters from ParallelRegion() and ForReductionCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, Operations op, ref T reduce_to, ActionRef2<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            T local = reduce_to;
+
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForReductionCollapse(firstRange, secondRange, op, ref local, action, schedule, chunk_size);
+            });
+
+            reduce_to = local;
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed reduction for loop. Contains all of the parameters from ParallelRegion() and ForReductionCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Operations op, ref T reduce_to, ActionRef3<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            T local = reduce_to;
+
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForReductionCollapse(firstRange, secondRange, thirdRange, op, ref local, action, schedule, chunk_size);
+            });
+
+            reduce_to = local;
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed reduction for loop. Contains all of the parameters from ParallelRegion() and ForReductionCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="fourthRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Operations op, ref T reduce_to, ActionRef4<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            T local = reduce_to;
+
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForReductionCollapse(firstRange, secondRange, thirdRange, fourthRange, op, ref local, action, schedule, chunk_size);
+            });
+
+            reduce_to = local;
+        }
+
+        /// <summary>
+        /// Creates a parallel collapsed reduction for loop. Contains all of the parameters from ParallelRegion() and ForReductionCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="ranges">A tuple representing the start and end of each of the for loops.</param>
+        /// <param name="op">The operation to be performed on the reduction.</param>
+        /// <param name="reduce_to">The variable to reduce to.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForReductionCollapse<T>((int, int)[] ranges, Operations op, ref T reduce_to, ActionRefN<T> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            T local = reduce_to;
+
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForReductionCollapse(ranges, op, ref local, action, schedule, chunk_size);
+            });
+
+            reduce_to = local;
         }
 
         /// <summary>

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -133,8 +133,8 @@ namespace DotMP
 
         /// <summary>
         /// Creates a collapsed for loop inside a parallel region.
-        /// A collapsed for loop can be used when you want to parallelize two nested for loops.
-        /// Instead of only parallelizing across the outermost loop, the two nested loops are flattened before scheduling,
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
         /// which has the effect of parallelizing across both loops.
         /// This has the effect multiplying the number of iterations the scheduler can work with,
         /// which can improve load balancing in irregular nested loops.
@@ -149,7 +149,89 @@ namespace DotMP
         {
             ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange });
 
-            For(0, (firstRange.Item2 - firstRange.Item1) * (secondRange.Item2 - secondRange.Item1), forAction, schedule, chunk_size);
+            For(0,
+                (firstRange.Item2 - firstRange.Item1) *
+                (secondRange.Item2 - secondRange.Item1),
+                forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
+        /// Creates a collapsed for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange, thirdRange });
+
+            For(0,
+                (firstRange.Item2 - firstRange.Item1) *
+                (secondRange.Item2 - secondRange.Item1) *
+                (thirdRange.Item2 - thirdRange.Item1),
+                forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
+        /// Creates a collapsed for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="fourthRange">A tuple representing the start and end of the fourth for loop.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange, thirdRange, fourthRange });
+
+            For(0,
+                (firstRange.Item2 - firstRange.Item1) *
+                (secondRange.Item2 - secondRange.Item1) *
+                (thirdRange.Item2 - thirdRange.Item1) *
+                (fourthRange.Item2 - fourthRange.Item1),
+                forAction, schedule, chunk_size);
+        }
+
+        /// <summary>
+        /// Creates a collapsed for loop inside a parallel region.
+        /// A collapsed for loop can be used when you want to parallelize two or more nested for loops.
+        /// Instead of only parallelizing across the outermost loop, the nested loops are flattened before scheduling,
+        /// which has the effect of parallelizing across both loops.
+        /// This has the effect multiplying the number of iterations the scheduler can work with,
+        /// which can improve load balancing in irregular nested loops.
+        /// </summary>
+        /// <param name="ranges">A tuple representing the start and end of each of the for loops.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
+        public static void ForCollapse((int, int)[] ranges, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null)
+        {
+            ForAction<object> forAction = new ForAction<object>(action, ranges);
+
+            int total_iters = 1;
+
+            foreach ((int i, int j) in ranges)
+                total_iters *= j - i;
+
+            For(0, total_iters, forAction, schedule, chunk_size);
         }
 
         /// <summary>

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -1,19 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.IO;
 using System.Threading;
 
 namespace DotMP
 {
-    /// <summary>
-    /// Action delegate that takes an int and a ref T as parameters.
-    /// </summary>
-    /// <typeparam name="T">Type of the ref parameter.</typeparam>
-    /// <param name="a">The ref parameter.</param>
-    /// <param name="i">The int parameter.</param>
-    public delegate void ActionRef<T>(ref T a, int i);
-
     /// <summary>
     /// The main class of DotMP.
     /// Contains all the main methods for parallelism.

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -685,7 +685,7 @@ namespace DotMP
         /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
         /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
         /// <param name="thirdRange">A tuple representing the start and end of the third for loop.</param>
-        /// <param name="fourthRange">A tuple representing the start and end of the third for loop.</param>
+        /// <param name="fourthRange">A tuple representing the start and end of the fourth for loop.</param>
         /// <param name="op">The operation to be performed on the reduction.</param>
         /// <param name="reduce_to">The variable to reduce to.</param>
         /// <param name="action">The action to be performed in the loop.</param>

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -141,16 +141,18 @@ namespace DotMP
             Barrier();
 
             ws.in_for = true;
+
+            ForAction<object> forAction = new ForAction<object>(action);
             // jscpd:ignore-end
 
             switch (schedule)
             {
                 case Schedule.Static:
-                    Iter.StaticLoop<object>(ws, GetThreadNum(), action, null, false);
+                    Iter.StaticLoop(ws, GetThreadNum(), forAction, false);
                     break;
                 case Schedule.Dynamic:
                 case Schedule.Guided:
-                    Iter.LoadBalancingLoop<object>(ws, action, null, false, schedule);
+                    Iter.LoadBalancingLoop(ws, forAction, false, schedule);
                     break;
             }
 
@@ -199,16 +201,18 @@ namespace DotMP
             Barrier();
 
             ws.in_for = true;
+
+            ForAction<T> forAction = new ForAction<T>(action);
             // jscpd:ignore-end
 
             switch (schedule)
             {
                 case Schedule.Static:
-                    Iter.StaticLoop(ws, GetThreadNum(), null, action, true);
+                    Iter.StaticLoop(ws, GetThreadNum(), forAction, true);
                     break;
                 case Schedule.Dynamic:
                 case Schedule.Guided:
-                    Iter.LoadBalancingLoop(ws, null, action, true, schedule);
+                    Iter.LoadBalancingLoop(ws, forAction, true, schedule);
                     break;
             }
 

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -369,6 +369,24 @@ namespace DotMP
         }
 
         /// <summary>
+        /// Creates a parallel collapsed for loop. Contains all of the parameters from ParallelRegion() and ForCollapse().
+        /// This is simply a convenience method for creating a parallel region and a collapsed for loop with a reduction inside of it.
+        /// </summary>
+        /// <param name="firstRange">A tuple representing the start and end of the first for loop.</param>
+        /// <param name="secondRange">A tuple representing the start and end of the second for loop.</param>
+        /// <param name="action">The action to be performed in the loop.</param>
+        /// <param name="schedule">The schedule of the loop, defaulting to static.</param>
+        /// <param name="chunk_size">The chunk size of the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        /// <param name="num_threads">The number of threads to be used in the loop, defaulting to null. If null, will be calculated on-the-fly.</param>
+        public static void ParallelForCollapse((int, int) firstRange, (int, int) secondRange, Action<int, int> action, Schedule schedule = Schedule.Static, uint? chunk_size = null, uint? num_threads = null)
+        {
+            ParallelRegion(num_threads: num_threads, action: () =>
+            {
+                ForCollapse(firstRange, secondRange, action, schedule, chunk_size);
+            });
+        }
+
+        /// <summary>
         /// Creates a sections region.
         /// Sections allows for the user to submit multiple, individual tasks to be distributed among threads in parallel.
         /// In parallel, each thread active will dequeue a callback and execute it.

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -352,7 +352,7 @@ namespace DotMP
                     int start3 = ranges[2].Item1;
                     diff1 = ranges[0].Item2 - start1;
                     diff2 = ranges[1].Item2 - start2;
-                    int diff3 = ranges[1].Item2 - start3;
+                    int diff3 = ranges[2].Item2 - start3;
 
                     for (curr_iter = start; curr_iter < end; curr_iter++)
                     {
@@ -381,7 +381,7 @@ namespace DotMP
                     start3 = ranges[2].Item1;
                     diff1 = ranges[0].Item2 - start1;
                     diff2 = ranges[1].Item2 - start2;
-                    diff3 = ranges[1].Item2 - start3;
+                    diff3 = ranges[2].Item2 - start3;
 
                     for (curr_iter = start; curr_iter < end; curr_iter++)
                     {

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -50,7 +50,7 @@ namespace DotMP
 
     /// <summary>
     /// Class encapsulating all of the possible callbacks in a Parallel.For-style loop.
-    /// This includes Parallel.For, Parallel.ForReduction, Parallel.ForCollapse, and Parallel.ForReductionCollapse.
+    /// This includes Parallel.For, Parallel.ForReduction&lt;T&gt;, Parallel.ForCollapse, and Parallel.ForReductionCollapse&lt;T&gt;.
     /// </summary>
     /// <typeparam name="T">The type of the reduction callback.</typeparam>
     internal class ForAction<T>
@@ -157,7 +157,10 @@ namespace DotMP
         /// </summary>
         private ActionSelector selector;
 
-        private (int, int)[] ranges;
+        /// <summary>
+        /// Represents the ranges of collapsed loops for future unflattening.
+        /// </summary>
+        private ValueTuple<int, int>[] ranges;
 
         /// <summary>
         /// Constructor for regular for loops with 1 variable.

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace DotMP
 {
     /// <summary>
@@ -7,4 +9,281 @@ namespace DotMP
     /// <param name="a">The ref parameter.</param>
     /// <param name="i">The int parameter.</param>
     public delegate void ActionRef<T>(ref T a, int i);
+
+    /// <summary>
+    /// Action delegate that takes two ints and a ref T as parameters.
+    /// </summary>
+    /// <typeparam name="T">Type of the ref parameter.</typeparam>
+    /// <param name="a">The ref parameter.</param>
+    /// <param name="i">The first int parameter.</param>
+    /// <param name="j">The second int parameter.</param>
+    public delegate void ActionRef2<T>(ref T a, int i, int j);
+
+    /// <summary>
+    /// Action delegate that takes three ints and a ref T as parameters.
+    /// </summary>
+    /// <typeparam name="T">Type of the ref parameter.</typeparam>
+    /// <param name="a">The ref parameter.</param>
+    /// <param name="i">The first int parameter.</param>
+    /// <param name="j">The second int parameter.</param>
+    /// <param name="k">The third int parameter.</param>
+    public delegate void ActionRef3<T>(ref T a, int i, int j, int k);
+
+    /// <summary>
+    /// Action delegate that takes four ints and a ref T as parameters.
+    /// </summary>
+    /// <typeparam name="T">Type of the ref parameter.</typeparam>
+    /// <param name="a">The ref parameter.</param>
+    /// <param name="i">The first int parameter.</param>
+    /// <param name="j">The second int parameter.</param>
+    /// <param name="k">The third int parameter.</param>
+    /// <param name="l">The fourth int parameter.</param>
+    public delegate void ActionRef4<T>(ref T a, int i, int j, int k, int l);
+
+    /// <summary>
+    /// Action delegate that takes an int[] and a ref T as parameters.
+    /// </summary>
+    /// <typeparam name="T">Type of the ref parameter.</typeparam>
+    /// <param name="a">The ref parameter.</param>
+    /// <param name="i">The int[] parameter.</param>
+    public delegate void ActionRefN<T>(ref T a, int[] i);
+
+    /// <summary>
+    /// Class encapsulating all of the possible callbacks in a Parallel.For-style loop.
+    /// This includes Parallel.For, Parallel.ForReduction, Parallel.ForCollapse, and Parallel.ForReductionCollapse.
+    /// </summary>
+    /// <typeparam name="T">The type of the reduction callback.</typeparam>
+    internal class ForAction<T>
+    {
+        /// <summary>
+        /// Enum describing which actions can be selected.
+        /// </summary>
+        private enum ActionSelector
+        {
+            /// <summary>
+            /// A regular for loop with 1 variable.
+            /// </summary>
+            Regular,
+            /// <summary>
+            /// A reduction loop with 1 variable.
+            /// </summary>
+            Reduction,
+            /// <summary>
+            /// A collapsed loop with 2 variables.
+            /// </summary>
+            Collapse2,
+            /// <summary>
+            /// A collapsed loop with 3 variables.
+            /// </summary>
+            Collapse3,
+            /// <summary>
+            /// A collapsed loop with 4 variables.
+            /// </summary>
+            Collapse4,
+            /// <summary>
+            /// A collapsed loop with unbounded variables.
+            /// </summary>
+            CollapseN,
+            /// <summary>
+            /// A reduction and collapsed loop with 2 variables.
+            /// </summary>
+            ReductionCollapse2,
+            /// <summary>
+            /// A reduction and collapsed loop with 3 variables.
+            /// </summary>
+            ReductionCollapse3,
+            /// <summary>
+            /// A reduction and collapsed loop with 4 variables.
+            /// </summary>
+            ReductionCollapse4,
+            /// <summary>
+            /// A reduction and collapsed loop with unbounded variables.
+            /// </summary>
+            ReductionCollapseN,
+        }
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.Regular
+        /// </summary>
+        private Action<int> omp_fn;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.Reduction
+        /// </summary>
+        private ActionRef<T> omp_red;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.Collapse2
+        /// </summary>
+        private Action<int, int> omp_col_2;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.Collapse3
+        /// </summary>
+        private Action<int, int, int> omp_col_3;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.Collapse4
+        /// </summary>
+        private Action<int, int, int, int> omp_col_4;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.CollapseN
+        /// </summary>
+        private Action<int[]> omp_col_n;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.ReductionCollapse2
+        /// </summary>
+        private ActionRef2<T> omp_red_col_2;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.ReductionCollapse3
+        /// </summary>
+        private ActionRef3<T> omp_red_col_3;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.ReductionCollapse4
+        /// </summary>
+        private ActionRef4<T> omp_red_col_4;
+
+        /// <summary>
+        /// Represents an action that can be selected via ActionSelector.ReductionCollapseN
+        /// </summary>
+        private ActionRefN<T> omp_red_col_n;
+
+        /// <summary>
+        /// Holds the data regarding which action to select.
+        /// </summary>
+        private ActionSelector selector;
+
+        /// <summary>
+        /// Constructor for regular for loops with 1 variable.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(Action<int> action)
+        {
+            omp_fn = action;
+            selector = ActionSelector.Regular;
+        }
+
+        /// <summary>
+        /// Constructor for reduction for loops with 1 variable.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(ActionRef<T> action)
+        {
+            omp_red = action;
+            selector = ActionSelector.Reduction;
+        }
+
+        /// <summary>
+        /// Constructor for collapsed for loops with 2 variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(Action<int, int> action)
+        {
+            omp_col_2 = action;
+            selector = ActionSelector.Collapse2;
+        }
+
+        /// <summary>
+        /// Constructor for collapsed for loops with 3 variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(Action<int, int, int> action)
+        {
+            omp_col_3 = action;
+            selector = ActionSelector.Collapse3;
+        }
+
+        /// <summary>
+        /// Constructor for collapsed for loops with 4 variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(Action<int, int, int, int> action)
+        {
+            omp_col_4 = action;
+            selector = ActionSelector.Collapse4;
+        }
+
+        /// <summary>
+        /// Constructor for collapsed for loops with unbounded variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(Action<int[]> action)
+        {
+            omp_col_n = action;
+            selector = ActionSelector.CollapseN;
+        }
+
+        /// <summary>
+        /// Constructor for reduction collapsed for loops with 2 variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(ActionRef2<T> action)
+        {
+            omp_red_col_2 = action;
+            selector = ActionSelector.ReductionCollapse2;
+        }
+
+        /// <summary>
+        /// Constructor for reduction collapsed for loops with 3 variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(ActionRef3<T> action)
+        {
+            omp_red_col_3 = action;
+            selector = ActionSelector.ReductionCollapse3;
+        }
+
+        /// <summary>
+        /// Constructor for reduction collapsed for loops with 4 variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(ActionRef4<T> action)
+        {
+            omp_red_col_4 = action;
+            selector = ActionSelector.ReductionCollapse4;
+        }
+
+        /// <summary>
+        /// Constructor for reduction collapsed for loops with unbounded variables.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        internal ForAction(ActionRefN<T> action)
+        {
+            omp_red_col_n = action;
+            selector = ActionSelector.ReductionCollapseN;
+        }
+
+        /// <summary>
+        /// Executes a chunk using the action selected by ForAction.selector
+        /// </summary>
+        /// <param name="curr_iter">A reference to the current iteration.</param>
+        /// <param name="start">The start of the chunk, inclusive.</param>
+        /// <param name="end">The end of the chunk, exclusive.</param>
+        /// <param name="local">The local variable to reduce to.</param>
+        /// <exception cref="NotImplementedException">Thrown if the current action is not implemented.</exception>
+        internal void PerformLoop(ref int curr_iter, int start, int end, ref T local)
+        {
+            switch (selector)
+            {
+                case ActionSelector.Regular:
+                    for (curr_iter = start; curr_iter < end; curr_iter++)
+                    {
+                        omp_fn(curr_iter);
+                    }
+                    break;
+                case ActionSelector.Reduction:
+                    for (curr_iter = start; curr_iter < end; curr_iter++)
+                    {
+                        omp_red(ref local, curr_iter);
+                    }
+                    break;
+                default:
+                    throw new NotImplementedException("This callback is not implemented with the scheduler.");
+            }
+        }
+    }
 }

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -300,10 +300,10 @@ namespace DotMP
                     }
                     break;
                 case ActionSelector.Collapse2:
-                    int diff1 = ranges[0].Item2 - ranges[0].Item1;
-                    int diff2 = ranges[1].Item2 - ranges[1].Item1;
                     int start1 = ranges[0].Item1;
                     int start2 = ranges[1].Item1;
+                    int diff1 = ranges[0].Item2 - start1;
+                    int diff2 = ranges[1].Item2 - start2;
 
                     for (curr_iter = start; curr_iter < end; curr_iter++)
                     {

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -498,8 +498,6 @@ namespace DotMP
                         omp_red_col_n(ref local, indices);
                     }
                     break;
-                default:
-                    throw new NotImplementedException("This callback is not implemented with the scheduler.");
             }
         }
     }

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -1,0 +1,10 @@
+namespace DotMP
+{
+    /// <summary>
+    /// Action delegate that takes an int and a ref T as parameters.
+    /// </summary>
+    /// <typeparam name="T">Type of the ref parameter.</typeparam>
+    /// <param name="a">The ref parameter.</param>
+    /// <param name="i">The int parameter.</param>
+    public delegate void ActionRef<T>(ref T a, int i);
+}

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -310,6 +310,7 @@ namespace DotMP
 
         /// <summary>
         /// Executes a chunk using the action selected by ForAction.selector
+        /// TODO: Optimize this whole function.
         /// </summary>
         /// <param name="curr_iter">A reference to the current iteration.</param>
         /// <param name="start">The start of the chunk, inclusive.</param>
@@ -343,6 +344,51 @@ namespace DotMP
                         int i = curr_iter / diff2 + start1;
                         int j = curr_iter % diff2 + start2;
                         omp_col_2(i, j);
+                    }
+                    break;
+                case ActionSelector.Collapse3:
+                    start1 = ranges[0].Item1;
+                    start2 = ranges[1].Item1;
+                    int start3 = ranges[2].Item1;
+                    diff1 = ranges[0].Item2 - start1;
+                    diff2 = ranges[1].Item2 - start2;
+                    int diff3 = ranges[1].Item2 - start3;
+
+                    for (curr_iter = start; curr_iter < end; curr_iter++)
+                    {
+                        int i = curr_iter / (diff2 * diff3) + start1;
+                        int j = curr_iter % (diff2 * diff3) / diff3 + start2;
+                        int k = curr_iter % diff3 + start3;
+                        omp_col_3(i, j, k);
+                    }
+                    break;
+                case ActionSelector.ReductionCollapse2:
+                    start1 = ranges[0].Item1;
+                    start2 = ranges[1].Item1;
+                    diff1 = ranges[0].Item2 - start1;
+                    diff2 = ranges[1].Item2 - start2;
+
+                    for (curr_iter = start; curr_iter < end; curr_iter++)
+                    {
+                        int i = curr_iter / diff2 + start1;
+                        int j = curr_iter % diff2 + start2;
+                        omp_red_col_2(ref local, i, j);
+                    }
+                    break;
+                case ActionSelector.ReductionCollapse3:
+                    start1 = ranges[0].Item1;
+                    start2 = ranges[1].Item1;
+                    start3 = ranges[2].Item1;
+                    diff1 = ranges[0].Item2 - start1;
+                    diff2 = ranges[1].Item2 - start2;
+                    diff3 = ranges[1].Item2 - start3;
+
+                    for (curr_iter = start; curr_iter < end; curr_iter++)
+                    {
+                        int i = curr_iter / (diff2 * diff3) + start1;
+                        int j = curr_iter % (diff2 * diff3) / diff3 + start2;
+                        int k = curr_iter % diff3 + start3;
+                        omp_red_col_3(ref local, i, j, k);
                     }
                     break;
                 default:

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -157,6 +157,8 @@ namespace DotMP
         /// </summary>
         private ActionSelector selector;
 
+        private (int, int)[] ranges;
+
         /// <summary>
         /// Constructor for regular for loops with 1 variable.
         /// </summary>
@@ -181,80 +183,96 @@ namespace DotMP
         /// Constructor for collapsed for loops with 2 variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(Action<int, int> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(Action<int, int> action, (int, int)[] ranges)
         {
             omp_col_2 = action;
             selector = ActionSelector.Collapse2;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for collapsed for loops with 3 variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(Action<int, int, int> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(Action<int, int, int> action, (int, int)[] ranges)
         {
             omp_col_3 = action;
             selector = ActionSelector.Collapse3;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for collapsed for loops with 4 variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(Action<int, int, int, int> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(Action<int, int, int, int> action, (int, int)[] ranges)
         {
             omp_col_4 = action;
             selector = ActionSelector.Collapse4;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for collapsed for loops with unbounded variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(Action<int[]> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(Action<int[]> action, (int, int)[] ranges)
         {
             omp_col_n = action;
             selector = ActionSelector.CollapseN;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for reduction collapsed for loops with 2 variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(ActionRef2<T> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(ActionRef2<T> action, (int, int)[] ranges)
         {
             omp_red_col_2 = action;
             selector = ActionSelector.ReductionCollapse2;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for reduction collapsed for loops with 3 variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(ActionRef3<T> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(ActionRef3<T> action, (int, int)[] ranges)
         {
             omp_red_col_3 = action;
             selector = ActionSelector.ReductionCollapse3;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for reduction collapsed for loops with 4 variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(ActionRef4<T> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(ActionRef4<T> action, (int, int)[] ranges)
         {
             omp_red_col_4 = action;
             selector = ActionSelector.ReductionCollapse4;
+            this.ranges = ranges;
         }
 
         /// <summary>
         /// Constructor for reduction collapsed for loops with unbounded variables.
         /// </summary>
         /// <param name="action">The action to run.</param>
-        internal ForAction(ActionRefN<T> action)
+        /// <param name="ranges">The ranges of the collapsed loop.</param>
+        internal ForAction(ActionRefN<T> action, (int, int)[] ranges)
         {
             omp_red_col_n = action;
             selector = ActionSelector.ReductionCollapseN;
+            this.ranges = ranges;
         }
 
         /// <summary>

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -401,11 +401,11 @@ namespace DotMP
         /// <param name="start">The start of the chunk, inclusive.</param>
         /// <param name="end">The end of the chunk, exclusive.</param>
         /// <param name="local">The local variable to reduce to.</param>
-        /// <exception cref="NotImplementedException">Thrown if the current action is not implemented.</exception>
         internal void PerformLoop(ref int curr_iter, int start, int end, ref T local)
         {
             switch (selector)
             {
+                /* jscpd:ignore-start */
                 case ActionSelector.Regular:
                     for (curr_iter = start; curr_iter < end; curr_iter++)
                     {
@@ -498,6 +498,7 @@ namespace DotMP
                         omp_red_col_n(ref local, indices);
                     }
                     break;
+                    /* jscpd:ignore-end */
             }
         }
     }

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -299,6 +299,19 @@ namespace DotMP
                         omp_red(ref local, curr_iter);
                     }
                     break;
+                case ActionSelector.Collapse2:
+                    int diff1 = ranges[0].Item2 - ranges[0].Item1;
+                    int diff2 = ranges[1].Item2 - ranges[1].Item1;
+                    int start1 = ranges[0].Item1;
+                    int start2 = ranges[1].Item1;
+
+                    for (curr_iter = start; curr_iter < end; curr_iter++)
+                    {
+                        int i = curr_iter / diff2 + start1;
+                        int j = curr_iter % diff2 + start2;
+                        omp_col_2(i, j);
+                    }
+                    break;
                 default:
                     throw new NotImplementedException("This callback is not implemented with the scheduler.");
             }

--- a/DotMP/Wrappers.cs
+++ b/DotMP/Wrappers.cs
@@ -163,6 +163,16 @@ namespace DotMP
         private ValueTuple<int, int>[] ranges;
 
         /// <summary>
+        /// Tracks if the action represents a collapsed for loop.
+        /// </summary>
+        internal bool IsCollapse { get; private set; }
+
+        /// <summary>
+        /// Tracks if the action represents a reduction loop.
+        /// </summary>
+        internal bool IsReduction { get; private set; }
+
+        /// <summary>
         /// Constructor for regular for loops with 1 variable.
         /// </summary>
         /// <param name="action">The action to run.</param>
@@ -170,6 +180,8 @@ namespace DotMP
         {
             omp_fn = action;
             selector = ActionSelector.Regular;
+            IsCollapse = false;
+            IsReduction = false;
         }
 
         /// <summary>
@@ -180,6 +192,8 @@ namespace DotMP
         {
             omp_red = action;
             selector = ActionSelector.Reduction;
+            IsCollapse = false;
+            IsReduction = true;
         }
 
         /// <summary>
@@ -192,6 +206,8 @@ namespace DotMP
             omp_col_2 = action;
             selector = ActionSelector.Collapse2;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = false;
         }
 
         /// <summary>
@@ -204,6 +220,8 @@ namespace DotMP
             omp_col_3 = action;
             selector = ActionSelector.Collapse3;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = false;
         }
 
         /// <summary>
@@ -216,6 +234,8 @@ namespace DotMP
             omp_col_4 = action;
             selector = ActionSelector.Collapse4;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = false;
         }
 
         /// <summary>
@@ -228,6 +248,8 @@ namespace DotMP
             omp_col_n = action;
             selector = ActionSelector.CollapseN;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = false;
         }
 
         /// <summary>
@@ -240,6 +262,8 @@ namespace DotMP
             omp_red_col_2 = action;
             selector = ActionSelector.ReductionCollapse2;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = true;
         }
 
         /// <summary>
@@ -252,6 +276,8 @@ namespace DotMP
             omp_red_col_3 = action;
             selector = ActionSelector.ReductionCollapse3;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = true;
         }
 
         /// <summary>
@@ -264,6 +290,8 @@ namespace DotMP
             omp_red_col_4 = action;
             selector = ActionSelector.ReductionCollapse4;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = true;
         }
 
         /// <summary>
@@ -276,6 +304,8 @@ namespace DotMP
             omp_red_col_n = action;
             selector = ActionSelector.ReductionCollapseN;
             this.ranges = ranges;
+            IsCollapse = true;
+            IsReduction = true;
         }
 
         /// <summary>

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 DN=dotnet
 BUILD=Release
 
-all: docs build tests examples
+all: docs build tests examples benches
 
 examples: examples-cs examples-dmp examples-seq
+
+benches:
+	$(DN) build -c Release benchmarks/HeatTransfer
 
 examples-cs:
 	$(DN) build -c $(BUILD) examples/CSParallel/ConjugateGradient
@@ -52,3 +55,4 @@ clean:
 	rm -rf examples/Serial/ConjugateGradient/bin examples/Serial/ConjugateGradient/obj
 	rm -rf examples/Serial/HeatTransfer/bin examples/Serial/HeatTransfer/obj
 	rm -rf examples/Serial/GEMM/bin examples/Serial/GEMM/obj
+	rm -rf benchmarks/HeatTransfer/bin benchmarks/HeatTransfer/obj benchmarks/HeatTransfer/BenchmarkDotNet.Artifacts

--- a/README.md
+++ b/README.md
@@ -202,6 +202,89 @@ DotMP.Parallel.ParallelForReduction(a, b, op, ref local, (ref type local, int i)
 ```
 This function supports all of the optional parameters of `ParallelRegion` and `ForReduction`, and is merely a wrapper around those two functions for conciseness.
 
+### For with Collapse
+Given the OpenMP:
+```c
+#pragma omp for collapse(n)
+for (int i = a, i < b; i++)
+    for (int j = c, j < d; j++)
+        // ...
+            for (int k = e; k < f; k++)
+                work(i, j, /* ... */, k);
+```
+DotMP provides:
+```cs
+DotMP.Parallel.ForCollapse((a, b), (c, d), /* ... */, (e, f), (i, j, /* ... */, k) => {
+    work(i, j, /* ... */, k);
+});
+```
+If four or fewer loops are being collapsed, overloads of `ForCollapse` exist to easily collapse said loops.
+If greater than four loops are being collapsed, then the user should pass an array of tuples as the first argument, and accept an array of indices in the lambda.
+
+This function supports all of the optional parameters of `For`.
+
+### For with Reduction and Collapse
+Given the OpenMP:
+```c
+type local = c;
+
+#pragma omp for reduction(op:local) collapse(n)
+for (int i = a, i < b; i++)
+    for (int j = c, j < d; j++)
+        // ...
+            for (int k = e; k < f; k++)
+                local `op` f(i, j, /* ... */, k);
+```
+DotMP provides:
+```cs
+type local = c;
+
+DotMP.Parallel.ForReductionCollapse((a, b), (c, d), /* ... */, (e, f), op, ref local, (ref type local, int i, int j, /* ... */, int k) => {
+    local `op` f(i, j, /* ... */, k);
+});
+```
+This function is a combination of `ForCollapse` and `ForReduction`, and supports all of the optional parameters thereof.
+
+### Parallel For with Collapse
+Given the OpenMP:
+```c
+#pragma omp parallel for collapse(n)
+for (int i = a, i < b; i++)
+    for (int j = c, j < d; j++)
+        // ...
+            for (int k = e; k < f; k++)
+                work(i, j, /* ... */, k);
+```
+DotMP provides:
+```cs
+DotMP.Parallel.ParallelForCollapse((a, b), (c, d), /* ... */, (e, f), (i, j, /* ... */, k) => {
+    work(i, j, /* ... */, k);
+});
+```
+This function supports all of the optional parameters of `ParallelRegion` and `ForCollapse`, and is merely a wrapper around those two functions for conciseness.
+
+### Parallel For with Reduction and Collapse
+Given the OpenMP:
+```c
+type local = c;
+
+#pragma omp parallel for reduction(op:local) collapse(n)
+for (int i = a, i < b; i++)
+    for (int j = c, j < d; j++)
+        // ...
+            for (int k = e; k < f; k++)
+                local `op` f(i, j, /* ... */, k);
+```
+DotMP provides:
+```cs
+type local = c;
+
+DotMP.Parallel.ParallelForReductionCollapse((a, b), (c, d), /* ... */, (e, f), op, ref local, (ref type local, int i, int j, /* ... */, int k) => {
+    local `op` f(i, j, /* ... */, k);
+});
+```
+This function supports all of the optional parameters of `ParallelRegion` and `ForReductionCollapse`, and is merely a wrapper around those two functions for conciseness.
+
 ### Sections
 Given the OpenMP:
 ```c

--- a/benchmarks/HeatTransfer/HeatTransfer.csproj
+++ b/benchmarks/HeatTransfer/HeatTransfer.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DotMP\DotMP.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.9" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/benchmarks/HeatTransfer/Program.cs
+++ b/benchmarks/HeatTransfer/Program.cs
@@ -3,6 +3,8 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Diagnosers;
 
+/* jscpd:ignore-start */
+
 [SimpleJob(RuntimeMoniker.Net60)]
 [SimpleJob(RuntimeMoniker.Net70)]
 [ThreadingDiagnoser]
@@ -220,6 +222,8 @@ public class HeatTransferForCollapse
         });
     }
 }
+
+/* jscpd:ignore-end */
 
 // driver
 public class Program

--- a/benchmarks/HeatTransfer/Program.cs
+++ b/benchmarks/HeatTransfer/Program.cs
@@ -1,0 +1,241 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Diagnosers;
+
+[SimpleJob(RuntimeMoniker.Net60)]
+[SimpleJob(RuntimeMoniker.Net70)]
+[ThreadingDiagnoser]
+[HardwareCounters]
+// test heat transfer using taskloops
+public class HeatTransferTaskloop
+{
+    // scratch array
+    private double[,] scratch = new double[0, 0];
+    // grid array
+    private double[,] grid = new double[0, 0];
+
+    // test dims of 100x100, 1000x1000, and 5000x5000
+    [Params(100, 1000, 5000)]
+    public int dim;
+
+    // test with 10 steps and 100 steps
+    [Params(10, 100)]
+    public int steps;
+
+    // change this to configure the number of threads to use
+    public uint num_threads = 6;
+
+    // run the setup
+    [GlobalSetup]
+    public void Setup()
+    {
+        scratch = new double[dim, dim];
+        grid = new double[dim, dim];
+
+        grid[0, dim / 2 - 1] = 100.0;
+        grid[0, dim / 2] = 100.0;
+    }
+
+    //run the simulation
+    [Benchmark]
+    public void DoSimulation()
+    {
+        // spawn a parallel region
+        DotMP.Parallel.ParallelRegion(num_threads: num_threads, action: () =>
+        {
+            //do the steps
+            for (int i = 0; i < steps; i++)
+            {
+                DoStep();
+            }
+        });
+    }
+
+    //do a step of the heat transfer simulation
+    public void DoStep()
+    {
+        DotMP.Parallel.Master(() =>
+        {
+            //iterate over all cells not on the border
+            var dep = DotMP.Parallel.Taskloop(1, dim - 1, action: i =>
+            {
+                for (int j = 1; j < dim - 1; j++)
+                {
+                    //set the scratch array to the average of the surrounding cells
+                    scratch[i, j] = 0.25 * (grid[i - 1, j] + grid[i + 1, j] + grid[i, j - 1] + grid[i, j + 1]);
+                }
+            });
+
+            //copy the scratch array to the grid array
+            DotMP.Parallel.Taskloop(1, dim - 1, depends: dep, action: i =>
+            {
+                for (int j = 1; j < dim - 1; j++)
+                {
+                    grid[i, j] = scratch[i, j];
+                }
+            });
+        });
+
+        DotMP.Parallel.Taskwait();
+    }
+}
+
+[SimpleJob(RuntimeMoniker.Net60)]
+[SimpleJob(RuntimeMoniker.Net70)]
+[ThreadingDiagnoser]
+[HardwareCounters]
+// test heat transfer using Parallel.For
+public class HeatTransferFor
+{
+    // scratch array
+    private double[,] scratch = new double[0, 0];
+    // grid array
+    private double[,] grid = new double[0, 0];
+
+    // test dims of 100x100, 1000x1000, and 5000x5000
+    [Params(100, 1000, 5000)]
+    public int dim;
+
+    // test with 10 steps and 100 steps
+    [Params(10, 100)]
+    public int steps;
+
+    // change this to configure the number of threads to use
+    public uint num_threads = 6;
+
+    // run the setup
+    [GlobalSetup]
+    public void Setup()
+    {
+        scratch = new double[dim, dim];
+        grid = new double[dim, dim];
+
+        grid[0, dim / 2 - 1] = 100.0;
+        grid[0, dim / 2] = 100.0;
+    }
+
+    //run the simulation
+    [Benchmark]
+    public void DoSimulation()
+    {
+        // spawn a parallel region
+        DotMP.Parallel.ParallelRegion(num_threads: num_threads, action: () =>
+        {
+            //do the steps
+            for (int i = 0; i < steps; i++)
+            {
+                DoStep();
+            }
+        });
+    }
+
+    //do a step of the heat transfer simulation
+    public void DoStep()
+    {
+        //iterate over all cells not on the border
+        DotMP.Parallel.For(1, dim - 1, action: i =>
+        {
+            for (int j = 1; j < dim - 1; j++)
+            {
+                //set the scratch array to the average of the surrounding cells
+                scratch[i, j] = 0.25 * (grid[i - 1, j] + grid[i + 1, j] + grid[i, j - 1] + grid[i, j + 1]);
+            }
+        });
+
+        //copy the scratch array to the grid array
+        DotMP.Parallel.For(1, dim - 1, action: i =>
+        {
+            for (int j = 1; j < dim - 1; j++)
+            {
+                grid[i, j] = scratch[i, j];
+            }
+        });
+    }
+}
+
+[SimpleJob(RuntimeMoniker.Net60)]
+[SimpleJob(RuntimeMoniker.Net70)]
+[ThreadingDiagnoser]
+[HardwareCounters]
+// test heat transfer using Parallel.ForCollapse
+public class HeatTransferForCollapse
+{
+    // scratch array
+    private double[,] scratch = new double[0, 0];
+    // grid array
+    private double[,] grid = new double[0, 0];
+
+    // test dims of 100x100, 1000x1000, and 5000x5000
+    [Params(100, 1000, 5000)]
+    public int dim;
+
+    // test with 10 steps and 100 steps
+    [Params(10, 100)]
+    public int steps;
+
+    // change this to configure the number of threads to use
+    public uint num_threads = 6;
+
+    // run the setup
+    [GlobalSetup]
+    public void Setup()
+    {
+        scratch = new double[dim, dim];
+        grid = new double[dim, dim];
+
+        grid[0, dim / 2 - 1] = 100.0;
+        grid[0, dim / 2] = 100.0;
+    }
+
+    //run the simulation
+    [Benchmark]
+    public void DoSimulation()
+    {
+        // spawn a parallel region
+        DotMP.Parallel.ParallelRegion(num_threads: num_threads, action: () =>
+        {
+            //do the steps
+            for (int i = 0; i < steps; i++)
+            {
+                DoStep();
+            }
+        });
+    }
+
+    //do a step of the heat transfer simulation
+    public void DoStep()
+    {
+        //iterate over all cells not on the border
+        DotMP.Parallel.ForCollapse((1, dim - 1), (1, dim - 1), action: (i, j) =>
+        {
+            //set the scratch array to the average of the surrounding cells
+            scratch[i, j] = 0.25 * (grid[i - 1, j] + grid[i + 1, j] + grid[i, j - 1] + grid[i, j + 1]);
+        });
+
+        //copy the scratch array to the grid array
+        DotMP.Parallel.ForCollapse((1, dim - 1), (1, dim - 1), action: (i, j) =>
+        {
+            grid[i, j] = scratch[i, j];
+        });
+    }
+}
+
+// driver
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        // check if a benchmark is specified
+        if (args.Length < 1)
+        {
+            throw new ArgumentException("Usage: dotnet run [taskloop|for|forcollapse] -c Release");
+        }
+
+        // run the specified benchmark
+        var summary = (args[0] == "taskloop") ? BenchmarkRunner.Run<HeatTransferTaskloop>()
+                    : (args[0] == "for") ? BenchmarkRunner.Run<HeatTransferFor>()
+                    : (args[0] == "forcollapse") ? BenchmarkRunner.Run<HeatTransferForCollapse>()
+                    : throw new ArgumentException("Usage: dotnet run [taskloop|for|forcollapse] -c Release");
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md
-->
# Which issue are you addressing?
Closes #39 
## How have you addressed the issue?
There has been a significant amount of refactoring done in the inner scheduler code to make this possible. This PR adds the `Wrappers.cs` file, which contains several new delegates and the `ForAction<T>` class. The methods in `Iter` now defer to `ForAction<T>.PerformLoop` to execute a chunk. The overhead should be negligible for non-collapsed loops. For collapsed loops, new control flow exists to un-flatten the indices from the scheduler into 2D, 3D, 4D, or even higher dimensional loops. This infrastructure exists with both non-reduction and reduction loops. New methods have been implemented into the `Parallel` class, including `ForCollapse`, `ForReductionCollapse`, `ParallelForCollapse`, and `ParallelForReductionCollapse`, each with several overloads based on the collapse factor.
## How have you tested your patch?
New tests have been written, namely `Collapse_works` and `Reduction_collapse_works`. Both of these are passing.
## Additional work
This PR also creates the `benchmarks/` subfolder, which will be the home for benchmarking DotMP. For a performance-oriented library, I am utterly ashamed at the lack of benchmarking that has happened. I hope to use `BenchmarkDotNet` to power benchmarks, but it is still a WIP.

I have also changed the access modifier of `Lock._lock` from `internal` to `private`. With the new API, there is no reason for `_lock` to be internal.
