### PR TITLE
Full rewrite of core scheduler, support custom schedulers

### DIFF
--- a/DotMP/DotMP.csproj
+++ b/DotMP/DotMP.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>DotMP</RootNamespace>
     <PackageId>DotMP</PackageId>
-    <Version>1.5.0</Version>
+    <Version>1.5.1-pre</Version>
     <Authors>Phillip Allen Lane,et al.</Authors>
     <PackageDescription>A library for fork-join parallelism in .NET, with an OpenMP-like API.</PackageDescription>
     <RepositoryUrl>https://github.com/computablee/DotMP</RepositoryUrl>
@@ -12,7 +12,7 @@
     <Copyright>Copyright (c) Phillip Allen Lane 2023</Copyright>
     <PackageReadmeFile>ProcessedREADME.md</PackageReadmeFile>
     <PackageTags>hpc,parallel,openmp,parallelization,high performance computing,threading</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
     <PackageReleaseNotes>Add collapsed worksharing for loops. Improve locking API. Bug fixes, documentation fixes, new logo, more rigorous testing, refactoring.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>pdbonly</DebugType>

--- a/DotMP/DotMP.csproj
+++ b/DotMP/DotMP.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>DotMP</RootNamespace>
     <PackageId>DotMP</PackageId>
-    <Version>1.5.1-pre</Version>
+    <Version>1.6.0-pre</Version>
     <Authors>Phillip Allen Lane,et al.</Authors>
     <PackageDescription>A library for fork-join parallelism in .NET, with an OpenMP-like API.</PackageDescription>
     <RepositoryUrl>https://github.com/computablee/DotMP</RepositoryUrl>

--- a/DotMP/Init.cs
+++ b/DotMP/Init.cs
@@ -70,20 +70,6 @@ namespace DotMP
             }
         }
         /// <summary>
-        /// A generic lock to be used within the parallel for loop.
-        /// </summary>
-        private static object ws_lock_pv = new object();
-        /// <summary>
-        /// Getter for the singleton object WorkShare.ws_lock_pv.
-        /// </summary>
-        internal object ws_lock
-        {
-            get
-            {
-                return ws_lock_pv;
-            }
-        }
-        /// <summary>
         /// The ending iteration of the parallel for loop, exclusive.
         /// </summary>
         internal int end { get; private set; }
@@ -130,11 +116,11 @@ namespace DotMP
         /// <summary>
         /// The schedule to be used in the parallel for loop.
         /// </summary>
-        private static Schedule? schedule_pv;
+        private static IScheduler schedule_pv;
         /// <summary>
         /// Getter and setter for singleton object WorkShare.schedule_pv.
         /// </summary>
-        internal Schedule? schedule
+        internal IScheduler schedule
         {
             get
             {
@@ -179,7 +165,7 @@ namespace DotMP
         /// <param name="chunk_size">The chunk size to use.</param>
         /// <param name="op">The operation for reduction, null if not a reduction.</param>
         /// <param name="schedule">The Parallel.Schedule to use.</param>
-        internal WorkShare(uint num_threads, Thread[] threads, int start, int end, uint chunk_size, Operations? op, Schedule schedule)
+        internal WorkShare(uint num_threads, Thread[] threads, int start, int end, uint chunk_size, Operations? op, IScheduler schedule)
         {
             this.end = end;
             this.num_threads = num_threads;
@@ -201,16 +187,6 @@ namespace DotMP
         /// Default constructor.
         /// </summary>
         internal WorkShare() { }
-
-        /// <summary>
-        /// Advance the start by some value.
-        /// </summary>
-        /// <param name="advance_by">The value to advance start by.</param>
-        /// <returns>The start of the current chunk to execute.</returns>
-        internal int Advance(int advance_by)
-        {
-            return Interlocked.Add(ref start_pv, advance_by) - advance_by;
-        }
 
         /// <summary>
         /// Add a value to reduction_list.

--- a/DotMP/Init.cs
+++ b/DotMP/Init.cs
@@ -142,12 +142,14 @@ namespace DotMP
         {
             get
             {
-                if (in_for_pv == null)
+                int tid = Parallel.GetThreadNum();
+
+                if (in_for_pv == null || tid >= in_for_pv.Length)
                 {
                     return false;
                 }
 
-                return in_for_pv[Parallel.GetThreadNum()];
+                return in_for_pv[tid];
             }
             set
             {

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -1,16 +1,32 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace DotMP
 {
     /// <summary>
     /// Represents the various scheduling strategies for parallel for loops.
-    /// Detailed explanations of each scheduling strategy are provided alongside each enumeration value.
+    /// Detailed explanations of each scheduling strategy are provided alongside each getter.
     /// If no schedule is specified, the default is <see cref="Schedule.Static"/>.
     /// </summary>
-    public enum Schedule
+    public abstract class Schedule : IScheduler
     {
+        /// <summary>
+        /// Internal holder for StaticScheduler object.
+        /// </summary>
+        private static StaticScheduler static_scheduler = new StaticScheduler();
+        /// <summary>
+        /// Internal holder for the DynamicScheduler object.
+        /// </summary>
+        private static DynamicScheduler dynamic_scheduler = new DynamicScheduler();
+        /// <summary>
+        /// Internal holder for the GuidedScheduler object.
+        /// </summary>
+        private static GuidedScheduler guided_scheduler = new GuidedScheduler();
+        /// <summary>
+        /// Internal holder for the RuntimeScheduler object.
+        /// </summary>
+        private static RuntimeScheduler runtime_scheduler = new RuntimeScheduler();
+
         /// <summary>
         /// The static scheduling strategy.
         /// Iterations are divided amongst threads in round-robin fashion.
@@ -25,7 +41,7 @@ namespace DotMP
         /// 
         /// Note: This is the default strategy if none is chosen.
         /// </summary>
-        Static,
+        public static Schedule Static { get => static_scheduler; }
 
         /// <summary>
         /// The dynamic scheduling strategy.
@@ -39,7 +55,7 @@ namespace DotMP
         /// Cons:
         /// - Increased overhead.
         /// </summary>
-        Dynamic,
+        public static Schedule Dynamic { get => dynamic_scheduler; }
 
         /// <summary>
         /// The guided scheduling strategy.
@@ -53,14 +69,235 @@ namespace DotMP
         /// Cons:
         /// - Might not handle loops with early heavy load imbalance efficiently.
         /// </summary>
-        Guided,
+        public static Schedule Guided { get => guided_scheduler; }
 
         /// <summary>
         /// Runtime-defined scheduling strategy.
         /// Schedule is determined by the 'OMP_SCHEDULE' environment variable.
         /// Expected format: "schedule[,chunk_size]", e.g., "static,128", "guided", or "dynamic,3".
         /// </summary>
-        Runtime
+        public static Schedule Runtime { get => runtime_scheduler; }
+
+        /// <summary>
+        /// Abstract method for builtin schedulers to override for implementing IScheduler.
+        /// </summary>
+        /// <param name="start">The start of the loop, inclusive.</param>
+        /// <param name="end">The end of the loop, exclusive.</param>
+        /// <param name="num_threads">The number of threads.</param>
+        /// <param name="chunk_size">The chunk size.</param>
+        public abstract void LoopInit(int start, int end, uint num_threads, uint chunk_size);
+
+        /// <summary>
+        /// Abstract method for builtin schedulers to override for implementing IScheduler.
+        /// </summary>
+        /// <param name="thread_id">The thread ID.</param>
+        /// <param name="start">The start of the chunk, inclusive.</param>
+        /// <param name="end">The end of the chunk, exclusive.</param>
+        public abstract void LoopNext(int thread_id, out int start, out int end);
+    }
+
+    /// <summary>
+    /// Implementation of static scheduling.
+    /// </summary>
+    internal class StaticScheduler : Schedule
+    {
+        /// <summary>
+        /// The chunk size.
+        /// </summary>
+        internal uint chunk_size;
+        /// <summary>
+        /// Number of threads.
+        /// </summary>
+        internal uint num_threads;
+        /// <summary>
+        /// Start of the loop, inclusive.
+        /// </summary>
+        internal int start;
+        /// <summary>
+        /// End of the loop, exclusive.
+        /// </summary>
+        internal int end;
+        /// <summary>
+        /// Bookkeeping to check which iteration each thread is on.
+        /// </summary>
+        internal int[] curr_iters;
+
+        /// <summary>
+        /// Override method for LoopInit, is called when first starting a static loop.
+        /// </summary>
+        /// <param name="start">The start of the loop, inclusive.</param>
+        /// <param name="end">The end of the loop, exclusive.</param>
+        /// <param name="num_threads">The number of threads.</param>
+        /// <param name="chunk_size">The chunk size.</param>
+        public override void LoopInit(int start, int end, uint num_threads, uint chunk_size)
+        {
+            this.chunk_size = chunk_size;
+            this.start = start;
+            this.end = end;
+            this.num_threads = num_threads;
+            curr_iters = new int[num_threads];
+            for (int i = 0; i < num_threads; i++)
+                curr_iters[i] = start + ((int)chunk_size * i);
+        }
+
+        /// <summary>
+        /// Override method for LoopNext, is called to get the bounds of the next chunk to execute.
+        /// </summary>
+        /// <param name="thread_id">The thread ID.</param>
+        /// <param name="start">The start of the chunk, inclusive.</param>
+        /// <param name="end">The end of the chunk, exclusive.</param>
+        public override void LoopNext(int thread_id, out int start, out int end)
+        {
+            start = curr_iters[thread_id];
+            end = Math.Min(start + (int)chunk_size, this.end);
+            curr_iters[thread_id] += (int)(chunk_size * num_threads);
+        }
+    }
+
+    /// <summary>
+    /// Implementation of dynamic scheduling.
+    /// </summary>
+    internal class DynamicScheduler : Schedule
+    {
+        /// <summary>
+        /// The chunk size.
+        /// </summary>
+        internal uint chunk_size;
+        /// <summary>
+        /// Number of threads.
+        /// </summary>
+        internal uint num_threads;
+        /// <summary>
+        /// Start of the loop, inclusive.
+        /// </summary>
+        internal int start;
+        /// <summary>
+        /// End of the loop, exclusive.
+        /// </summary>
+        internal int end;
+
+        /// <summary>
+        /// Override method for LoopInit, is called when first starting a dynamic loop.
+        /// </summary>
+        /// <param name="start">The start of the loop, inclusive.</param>
+        /// <param name="end">The end of the loop, exclusive.</param>
+        /// <param name="num_threads">The number of threads.</param>
+        /// <param name="chunk_size">The chunk size.</param>
+        public override void LoopInit(int start, int end, uint num_threads, uint chunk_size)
+        {
+            this.chunk_size = chunk_size;
+            this.start = start;
+            this.end = end;
+            this.num_threads = num_threads;
+        }
+
+        /// <summary>
+        /// Override method for LoopNext, is called to get the bounds of the next chunk to execute.
+        /// </summary>
+        /// <param name="thread_id">The thread ID.</param>
+        /// <param name="start">The start of the chunk, inclusive.</param>
+        /// <param name="end">The end of the chunk, exclusive.</param>
+        public override void LoopNext(int thread_id, out int start, out int end)
+        {
+            start = Interlocked.Add(ref this.start, (int)chunk_size) - (int)chunk_size;
+            end = Math.Min(start + (int)chunk_size, this.end);
+        }
+    }
+
+    /// <summary>
+    /// Implementation of guided scheduling.
+    /// </summary>
+    internal class GuidedScheduler : Schedule
+    {
+        /// <summary>
+        /// The chunk size.
+        /// </summary>
+        internal uint chunk_size;
+        /// <summary>
+        /// Number of threads.
+        /// </summary>
+        internal uint num_threads;
+        /// <summary>
+        /// Start of the loop, inclusive.
+        /// </summary>
+        internal int start;
+        /// <summary>
+        /// End of the loop, exclusive.
+        /// </summary>
+        internal int end;
+        /// <summary>
+        /// Lock for scheduling purposes.
+        /// </summary>
+        internal object sched_lock;
+
+        /// <summary>
+        /// Override method for LoopInit, is called when first starting a guided loop.
+        /// </summary>
+        /// <param name="start">The start of the loop, inclusive.</param>
+        /// <param name="end">The end of the loop, exclusive.</param>
+        /// <param name="num_threads">The number of threads.</param>
+        /// <param name="chunk_size">The chunk size.</param>
+        public override void LoopInit(int start, int end, uint num_threads, uint chunk_size)
+        {
+            this.chunk_size = chunk_size;
+            this.start = start;
+            this.end = end;
+            this.num_threads = num_threads;
+            this.sched_lock = new object();
+        }
+
+        /// <summary>
+        /// Override method for LoopNext, is called to get the bounds of the next chunk to execute.
+        /// </summary>
+        /// <param name="thread_id">The thread ID.</param>
+        /// <param name="start">The start of the chunk, inclusive.</param>
+        /// <param name="end">The end of the chunk, exclusive.</param>
+        public override void LoopNext(int thread_id, out int start, out int end)
+        {
+            int chunk_size;
+
+            lock (sched_lock)
+            {
+                start = this.start;
+                chunk_size = (int)Math.Max(this.chunk_size, (this.end - start) / (num_threads * 2));
+
+                this.start += chunk_size;
+            }
+
+            end = Math.Min(start + chunk_size, this.end);
+        }
+    }
+
+    /// <summary>
+    /// Placeholder for the runtime scheduler.
+    /// Is not meant to be called directly. The Parallel.FixArgs method should detect its existence and swap it out for another scheduler with implementations.
+    /// </summary>
+    internal class RuntimeScheduler : Schedule
+    {
+        /// <summary>
+        /// Should not be called.
+        /// </summary>
+        /// <param name="start">Unused.</param>
+        /// <param name="end">Unused.</param>
+        /// <param name="num_threads">Unused.</param>
+        /// <param name="chunk_size">Unused.</param>
+        /// <exception cref="NotImplementedException">Always thrown.</exception>
+        public override void LoopInit(int start, int end, uint num_threads, uint chunk_size)
+        {
+            throw new NotImplementedException("The runtime scheduler isn't meant to be called directly.");
+        }
+
+        /// <summary>
+        /// Should not be called.
+        /// </summary>
+        /// <param name="thread_id">Unused.</param>
+        /// <param name="start">Unused.</param>
+        /// <param name="end">Unused.</param>
+        /// <exception cref="NotImplementedException">Always thrown.</exception>
+        public override void LoopNext(int thread_id, out int start, out int end)
+        {
+            throw new NotImplementedException("The runtime scheduler isn't meant to be called directly.");
+        }
     }
 
     /// <summary>
@@ -69,121 +306,41 @@ namespace DotMP
     internal static class Iter
     {
         /// <summary>
-        /// Starts and controls a parallel for loop with static scheduling.
+        /// Performs a parallel for loop according to the scheduling policy provided.
         /// </summary>
-        /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
-        /// <param name="ws">The WorkShare object for state.</param>
-        /// <param name="thread_id">The thread ID.</param>
+        /// <typeparam name="T">The type of reductions, if applicable.</typeparam>
+        /// <param name="ws">The workshare singleton.</param>
+        /// <param name="scheduler">Scheduler to use while parallelizing the loop.</param>
         /// <param name="forAction">The function to be executed.</param>
-        internal static void StaticLoop<T>(WorkShare ws, int thread_id, ForAction<T> forAction)
-        {
-            int tid = thread_id;
-            Thr thr = ws.thread;
-
-            thr.curr_iter = (int)(ws.start + tid * ws.chunk_size);
-            int end = ws.end;
-
-            T local = default;
-            ws.SetLocal(ref local);
-
-            while (thr.curr_iter < end)
-                StaticNext(ws, thr, ws.chunk_size, forAction, ref local);
-
-            ws.AddReductionValue(local);
-        }
-
-        /// <summary>
-        /// Calculates the next chunk of iterations for a static scheduling parallel for loop and executes the appropriate function.
-        /// Each time this function is called, the calling thread receives a chunk of iterations to work on, as specified in the Iter.StaticLoop&lt;T&gt; documentation.
-        /// </summary>
-        /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
-        /// <param name="ws">The WorkShare object for state.</param>
-        /// <param name="thr">The Thr object for the current thread.</param>
-        /// <param name="chunk_size">The chunk size.</param>
-        /// <param name="forAction">The function to be executed.</param>
-        /// <param name="local">The local variable for reductions.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void StaticNext<T>(WorkShare ws, Thr thr, uint chunk_size, ForAction<T> forAction, ref T local)
-        {
-            int start = thr.curr_iter;
-            int end = (int)Math.Min(thr.curr_iter + chunk_size, ws.end);
-
-            forAction.PerformLoop(ref thr.working_iter, start, end, ref local);
-
-            thr.curr_iter += (int)(ws.num_threads * chunk_size);
-        }
-
-        /// <summary>
-        /// Specifies a load balancing loop, like dynamic or guided.
-        /// </summary>
-        /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
-        /// <param name="ws">The WorkShare object for state.</param>
-        /// <param name="forAction">The function to be executed.</param>
-        /// <param name="schedule">The schedule to use.</param>
-        internal static void LoadBalancingLoop<T>(WorkShare ws, ForAction<T> forAction, Schedule schedule)
+        internal static void PerformLoop<T>(WorkShare ws, IScheduler scheduler, ForAction<T> forAction)
         {
             Thr thr = ws.thread;
+            int start = ws.start;
             int end = ws.end;
+            uint num_threads = ws.num_threads;
+            uint chunk_size = ws.chunk_size;
+            int thread_id = Parallel.GetThreadNum();
 
             T local = default;
             if (forAction.IsReduction)
                 ws.SetLocal(ref local);
 
-            if (schedule == Schedule.Guided) while (ws.start < end)
-                {
-                    GuidedNext(ws, thr, forAction, ref local);
-                }
-            else if (schedule == Schedule.Dynamic) while (ws.start < end)
-                {
-                    DynamicNext(ws, thr, forAction, ref local);
-                }
+            Parallel.Master(() => scheduler.LoopInit(start, end, num_threads, chunk_size));
+            Parallel.Barrier();
 
-            ws.AddReductionValue(local);
-        }
+            int chunk_start, chunk_end;
+            ref int curr_iter = ref thr.working_iter;
 
-        /// <summary>
-        /// Calculates the next chunk of iterations for a dynamic scheduling parallel for loop and executes the appropriate function.
-        /// Each time this function is called, the calling thread receives a chunk of iterations to work on, as specified in the Iter.DynamicLoop&lt;T&gt; documentation.
-        /// </summary>
-        /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
-        /// <param name="ws">The WorkShare object for state.</param>
-        /// <param name="thr">The Thr object for the current thread.</param>
-        /// <param name="forAction">The function to be executed.</param>
-        /// <param name="local">The local variable for reductions.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void DynamicNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, ref T local)
-        {
-            int chunk_start = ws.Advance((int)ws.chunk_size);
-            int chunk_end = (int)Math.Min(chunk_start + ws.chunk_size, ws.end);
-
-            forAction.PerformLoop(ref thr.working_iter, chunk_start, chunk_end, ref local);
-        }
-
-        /// <summary>
-        /// Calculates the next chunk of iterations for a guided scheduling parallel for loop and executes the appropriate function.
-        /// Each time this function is called, the calling thread receives a chunk of iterations to work on, as specified in the Iter.GuidedLoop&lt;T&gt; documentation.
-        /// </summary>
-        /// <typeparam name="T">The type of the local variable for reductions.</typeparam>
-        /// <param name="ws">The WorkShare object for state.</param>
-        /// <param name="thr">The Thr object for the current thread.</param>
-        /// <param name="forAction">The function to be executed.</param>
-        /// <param name="local">The local variable for reductions.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void GuidedNext<T>(WorkShare ws, Thr thr, ForAction<T> forAction, ref T local)
-        {
-            int chunk_start, chunk_size;
-
-            lock (ws.ws_lock)
+            while (true)
             {
-                chunk_start = ws.start;
-                chunk_size = (int)Math.Max(ws.chunk_size, (ws.end - chunk_start) / (ws.num_threads * 2));
+                scheduler.LoopNext(thread_id, out chunk_start, out chunk_end);
 
-                ws.Advance(chunk_size);
+                if (chunk_start < chunk_end)
+                    forAction.PerformLoop(ref curr_iter, chunk_start, chunk_end, ref local);
+                else break;
             }
 
-            int chunk_end = Math.Min(chunk_start + chunk_size, ws.end);
-
-            forAction.PerformLoop(ref thr.working_iter, chunk_start, chunk_end, ref local);
+            ws.AddReductionValue(local);
         }
     }
 }

--- a/DotMP/Scheduler.cs
+++ b/DotMP/Scheduler.cs
@@ -1,0 +1,26 @@
+namespace DotMP
+{
+    /// <summary>
+    /// Interface for user-defined schedulers.
+    /// </summary>
+    public interface IScheduler
+    {
+        /// <summary>
+        /// Called before each worksharing parallel-for loop.
+        /// Used to instantiate scheduler variables.
+        /// </summary>
+        /// <param name="start">The start of the loop, inclusive.</param>
+        /// <param name="end">The end of the loop, exclusive.</param>
+        /// <param name="num_threads">The number of threads.</param>
+        /// <param name="chunk_size">Provided chunk size.</param>
+        public void LoopInit(int start, int end, uint num_threads, uint chunk_size);
+
+        /// <summary>
+        /// Called between each chunk to calculate the bounds of the next chunk.
+        /// </summary>
+        /// <param name="thread_id">The thread ID to provide a chunk to.</param>
+        /// <param name="start">The start of the chunk, inclusive.</param>
+        /// <param name="end">The end of the chunk, exclusive.</param>
+        public void LoopNext(int thread_id, out int start, out int end);
+    }
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request!

If this is your first time contributing, please read the contributor guidelines.
There are several types of low-quality PRs that are grounds for immediate rejection!
Please make sure you are not falling victim to that.
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md

-->

# Which issue are you addressing?

Closes #99 

## How have you addressed the issue?

There has been a full rewrite of the core worksharing parallel-for scheduling code. The entire codebase was stripped down and rethought. A new `IScheduler` interface has been added, which, when implemented, creates scheduler classes. Instantiations of those classes can be passed to all of the worksharing parallel-for methods, which will then use the custom scheduler.

The builtin schedulers of `static`, `dynamic`, and `guided` have been implemented using this API (albeit, by deriving from the `Schedule` abstract class to facilitate source compatibility). Lots of now unused fields have been removed, and the code is substantially more modular as a result. There was a ton of decoupling! Better OOP practice has been incorporated, too-- there is now a much greater reliance on polymorphism rather than switch/case. This is excellent for scalability, modularity, and maintainability.

Some further organization would probably fare well. Several classes are just thrown into a file without much thought. I would appreciate feedback on how to organize the new codebase.

## How have you tested your patch?

All unit tests pass, without needing any changes. All examples build, also without needing any changes. This proves that, to the best of my testing, source compatibility is maintained. I have added another unit test which uses a custom scheduler which schedules a loop in serial on thread 0. This test passes. I've also made sure to provide error handling where necessary, and update certain unit tests to make sure that the error handling works.

Code coverage is not perfect, I am waiting on the codecov bot to let me know where I have untested code, and I will work on that before merging the PR.

Finally, performance. I have not done extensive testing, but a basic test using the HeatTransfer benchmark proves that, at least for `dynamic` scheduling, the new code is actually **faster** than the old code!
