### PR TITLE
Implement proper exception handling from threads

### DIFF
--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1222,9 +1222,9 @@ namespace DotMPTests
         [Fact]
         public void Nested_parallelism_should_except()
         {
-            DotMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
+            Assert.Throws<DotMP.CannotPerformNestedParallelismException>(() =>
             {
-                Assert.Throws<DotMP.CannotPerformNestedParallelismException>(() =>
+                DotMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
                 {
                     DotMP.Parallel.ParallelRegion(num_threads: 8, action: () => { });
                 });
@@ -1297,28 +1297,28 @@ namespace DotMPTests
         [Fact]
         public void Nested_worksharing_should_except()
         {
-            DotMP.Parallel.ParallelFor(0, 10, num_threads: 4, action: i =>
+            Assert.Throws<DotMP.CannotPerformNestedWorksharingException>(() =>
             {
-                Assert.Throws<DotMP.CannotPerformNestedWorksharingException>(() =>
+                DotMP.Parallel.ParallelFor(0, 10, num_threads: 4, action: i =>
                 {
                     DotMP.Parallel.Single(0, () => { });
                 });
             });
 
-            DotMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
+            Assert.Throws<DotMP.CannotPerformNestedWorksharingException>(() =>
             {
-                DotMP.Parallel.Single(0, () =>
+                DotMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
                 {
-                    Assert.Throws<DotMP.CannotPerformNestedWorksharingException>(() =>
+                    DotMP.Parallel.Single(0, () =>
                     {
                         DotMP.Parallel.For(0, 10, action: i => { });
                     });
                 });
             });
 
-            DotMP.Parallel.ParallelFor(0, 10, num_threads: 4, action: i =>
+            Assert.Throws<DotMP.CannotPerformNestedWorksharingException>(() =>
             {
-                Assert.Throws<DotMP.CannotPerformNestedWorksharingException>(() =>
+                DotMP.Parallel.ParallelFor(0, 10, num_threads: 4, action: i =>
                 {
                     DotMP.Parallel.For(0, 10, j => { });
                 });

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1393,12 +1393,12 @@ namespace DotMPTests
 
             Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                DotMP.Parallel.ParallelFor(10, 0, chunk_size: 0, action: i => { });
+                DotMP.Parallel.ParallelFor(0, 10, chunk_size: 0, action: i => { });
             });
 
             Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                DotMP.Parallel.ParallelFor(10, 0, schedule: new Serial(), action: i => { });
+                DotMP.Parallel.ParallelFor(0, 10, schedule: new Serial(), action: i => { });
             });
 
             Assert.Throws<DotMP.InvalidArgumentsException>(() =>

--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1376,44 +1376,29 @@ namespace DotMPTests
         [Fact]
         public void Invalid_params_should_except()
         {
-            DotMP.Parallel.ParallelRegion(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.For(10, 0, i => { });
-                });
+                DotMP.Parallel.ParallelFor(10, 0, i => { });
             });
 
-            DotMP.Parallel.ParallelRegion(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.For(-1, 10, i => { });
-                });
+                DotMP.Parallel.ParallelFor(-1, 10, i => { });
             });
 
-            DotMP.Parallel.ParallelRegion(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.For(10, -5, i => { });
-                });
+                DotMP.Parallel.ParallelFor(10, -5, i => { });
             });
 
-            DotMP.Parallel.ParallelRegion(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.For(0, 10, chunk_size: 0, action: i => { });
-                });
+                DotMP.Parallel.ParallelFor(10, 0, chunk_size: 0, action: i => { });
             });
 
-            DotMP.Parallel.ParallelRegion(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.For(0, 10, schedule: new Serial(), action: i => { });
-                });
+                DotMP.Parallel.ParallelFor(10, 0, schedule: new Serial(), action: i => { });
             });
 
             Assert.Throws<DotMP.InvalidArgumentsException>(() =>
@@ -1421,28 +1406,19 @@ namespace DotMPTests
                 DotMP.Parallel.ParallelRegion(num_threads: 0, action: () => { });
             });
 
-            DotMP.Parallel.ParallelMaster(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.Taskloop(10, 0, i => { });
-                });
+                DotMP.Parallel.ParallelMasterTaskloop(10, 0, i => { });
             });
 
-            DotMP.Parallel.ParallelMaster(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.Taskloop(0, 10, grainsize: 0, action: i => { });
-                });
+                DotMP.Parallel.ParallelMasterTaskloop(0, 10, grainsize: 0, action: i => { });
             });
 
-            DotMP.Parallel.ParallelMaster(() =>
+            Assert.Throws<DotMP.InvalidArgumentsException>(() =>
             {
-                Assert.Throws<DotMP.InvalidArgumentsException>(() =>
-                {
-                    DotMP.Parallel.Taskloop(0, 10, num_tasks: 0, action: i => { });
-                });
+                DotMP.Parallel.ParallelMasterTaskloop(0, 10, num_tasks: 0, action: i => { });
             });
         }
 

--- a/DotMP/ForkedRegion.cs
+++ b/DotMP/ForkedRegion.cs
@@ -144,6 +144,7 @@ namespace DotMP
                 reg.threads[i].Name = i.ToString();
 
             in_parallel_prv = false;
+            in_workshare_prv = 0;
         }
 
         /// <summary>

--- a/DotMP/ForkedRegion.cs
+++ b/DotMP/ForkedRegion.cs
@@ -25,6 +25,37 @@ namespace DotMP
         /// The function to be executed.
         /// </summary>
         internal Action omp_fn;
+        /// <summary>
+        /// Exception caught from threads.
+        /// </summary>
+        internal Exception ex;
+
+        /// <summary>
+        /// Factory for creating threads in the threadpool.
+        /// </summary>
+        /// <param name="omp_fn">The function to execute.</param>
+        /// <param name="tid">The thread ID.</param>
+        /// <param name="num_threads">The total number of threads.</param>
+        /// <returns>The created Thread object.</returns>
+        internal Thread CreateThread(Action omp_fn, int tid, uint num_threads)
+        {
+            return new Thread(() =>
+            {
+                try
+                {
+                    omp_fn();
+                    Parallel.Taskwait();
+                }
+                catch (Exception ex)
+                {
+                    this.ex ??= ex;
+
+                    for (int i = 0; i < num_threads; i++)
+                        if (i != tid)
+                            threads[i].Interrupt();
+                }
+            });
+        }
 
         /// <summary>
         /// Creates a specified number of threads available to the parallel region, and sets the function to be executed.
@@ -36,14 +67,11 @@ namespace DotMP
         {
             threads = new Thread[num_threads];
             for (int i = 0; i < num_threads; i++)
-                threads[i] = new Thread(() =>
-                {
-                    omp_fn();
-                    Parallel.Taskwait();
-                });
+                threads[i] = CreateThread(omp_fn, i, num_threads);
             ws_lock = new object();
             this.num_threads = num_threads;
             this.omp_fn = omp_fn;
+            this.ex = null;
         }
     }
 
@@ -121,6 +149,7 @@ namespace DotMP
         /// <summary>
         /// Starts the threadpool and waits for all threads to complete before returning.
         /// </summary>
+        /// <exception cref="Exception">Thrown if an exception is caught in the threadpool. If multiple are thrown, the first one thrown is returned.</exception>
         internal void StartThreadpool()
         {
             in_parallel = true;
@@ -132,6 +161,9 @@ namespace DotMP
                 reg.threads[i].Join();
 
             in_parallel = false;
+
+            if (reg.ex is not null)
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(reg.ex).Throw();
         }
     }
 }

--- a/DotMP/Iter.cs
+++ b/DotMP/Iter.cs
@@ -99,7 +99,7 @@ namespace DotMP
     /// <summary>
     /// Implementation of static scheduling.
     /// </summary>
-    internal class StaticScheduler : Schedule
+    internal sealed class StaticScheduler : Schedule
     {
         /// <summary>
         /// The chunk size.
@@ -157,7 +157,7 @@ namespace DotMP
     /// <summary>
     /// Implementation of dynamic scheduling.
     /// </summary>
-    internal class DynamicScheduler : Schedule
+    internal sealed class DynamicScheduler : Schedule
     {
         /// <summary>
         /// The chunk size.
@@ -207,7 +207,7 @@ namespace DotMP
     /// <summary>
     /// Implementation of guided scheduling.
     /// </summary>
-    internal class GuidedScheduler : Schedule
+    internal sealed class GuidedScheduler : Schedule
     {
         /// <summary>
         /// The chunk size.
@@ -272,7 +272,7 @@ namespace DotMP
     /// Placeholder for the runtime scheduler.
     /// Is not meant to be called directly. The Parallel.FixArgs method should detect its existence and swap it out for another scheduler with implementations.
     /// </summary>
-    internal class RuntimeScheduler : Schedule
+    internal sealed class RuntimeScheduler : Schedule
     {
         /// <summary>
         /// Should not be called.


### PR DESCRIPTION
<!--

Thanks for opening a pull request!

If this is your first time contributing, please read the contributor guidelines.
There are several types of low-quality PRs that are grounds for immediate rejection!
Please make sure you are not falling victim to that.
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md

-->

# Which issue are you addressing?

Not an open issue, but needed to be done.

The problem was that exceptions thrown from within a `ParallelRegion` could only be caught from within the `ParallelRegion`, and not outside of it. This is because a `Thread` would terminate with an exception, which could not be caught from the main thread. This was troublesome and counter-intuitive from a programmer's perspective.

## How have you addressed the issue?

Creation of each thread now includes a try-catch block. If an exception is thrown from within a thread, that thread will set an exception object accessible to the main thread, then proceed to interrupt all other threads. Then, once all threads have joined, the main thread checks the exception object and, if set, will rethrow the exception, preserving the stack trace.

## How have you tested your patch?

All of the `*_should_except` methods in `DotMPTests` have been rewritten to have the `Assert.Throws` in the outermost scope. This ensures that all exceptions can be caught from outside of `ParallelRegion`s.
