### PR TITLE
Improve `GetThreadNum` performance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
       prefix: "nuget"
 
   - package-ecosystem: "nuget"
-    directory: "./benchmarks/HeatTransfer/"
+    directory: "./benchmarks/"
     schedule:
       interval: "weekly"
     labels:

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -5,11 +5,11 @@
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
-
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
  * License for more details.
-
+ *
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
@@ -47,6 +47,10 @@ namespace DotMP
         /// Number of threads to be used in the next parallel region, where 0 means that it will be determined on-the-fly.
         /// </summary>
         private static volatile uint num_threads = 0;
+        /// <summary>
+        /// Current thread num, cached.
+        /// </summary>
+        private static ThreadLocal<int> thread_num = new ThreadLocal<int>(() => Convert.ToInt32(Thread.CurrentThread.Name));
 
         /// <summary>
         /// Fixes the arguments for a parallel for loop.
@@ -1220,7 +1224,7 @@ namespace DotMP
                 throw new NotInParallelRegionException("Cannot get current thread number outside of a parallel region.");
             }
 
-            return Convert.ToInt32(Thread.CurrentThread.Name);
+            return thread_num.Value;
         }
 
         /// <summary>

--- a/benchmarks/HeatTransfer/Program.cs
+++ b/benchmarks/HeatTransfer/Program.cs
@@ -5,11 +5,11 @@
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
-
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
  * License for more details.
-
+ *
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */

--- a/benchmarks/Misc/Misc.csproj
+++ b/benchmarks/Misc/Misc.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DebugType>pdbonly</DebugType>

--- a/benchmarks/Misc/Misc.csproj
+++ b/benchmarks/Misc/Misc.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DotMP\DotMP.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+</Project>
+

--- a/benchmarks/Misc/Program.cs
+++ b/benchmarks/Misc/Program.cs
@@ -1,0 +1,53 @@
+/*
+ * DotMP - A collection of powerful abstractions for parallel programming in .NET with an OpenMP-like API. 
+ * Copyright (C) 2023 Phillip Allen Lane
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Diagnosers;
+
+[SimpleJob(RuntimeMoniker.Net60)]
+[ThreadingDiagnoser]
+[HardwareCounters]
+[EventPipeProfiler(EventPipeProfile.CpuSampling)]
+// tester for miscellaneous benchmarks
+public class MiscBench
+{
+    [Params(128)]
+    public int tid;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+    }
+
+    [Benchmark]
+    public void Bench()
+    {
+        int i = DotMP.Parallel.GetThreadNum();
+
+        if (i != this.tid)
+            throw new Exception(string.Format("Thread ID was not {0}.", tid));
+    }
+}
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkRunner.Run<MiscBench>();
+    }
+}

--- a/benchmarks/Misc/Program.cs
+++ b/benchmarks/Misc/Program.cs
@@ -18,6 +18,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Diagnosers;
+using System.Threading;
 
 [SimpleJob(RuntimeMoniker.Net60)]
 [ThreadingDiagnoser]
@@ -32,6 +33,7 @@ public class MiscBench
     [GlobalSetup]
     public void Setup()
     {
+        Thread.CurrentThread.Name = tid.ToString();
     }
 
     [Benchmark]


### PR DESCRIPTION
<!--

Thanks for opening a pull request!

If this is your first time contributing, please read the contributor guidelines.
There are several types of low-quality PRs that are grounds for immediate rejection!
Please make sure you are not falling victim to that.
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md

-->

# Which issue are you addressing?

Closes #110 

## How have you addressed the issue?

Using `ThreadLocal<T>`, the thread num is only calculated with `ToInt32` once, and from thereon is cached as a thread-local variable.

## How have you tested your patch?

A new `Misc` benchmark was added. Omitting the time to call `InParallel()`, the new `GetThreadNum()` runs in about 11ns, whereas the old took about 24ns. Negligible performance improvement for most code, but could be beneficial if `GetThreadNum()` is called millions or billions of times in a tight loop over the course of an application.

Of course, all unit tests still pass.
