### PR TITLE
Implement atomic subtraction for unsigned integers

### DIFF
--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -5,11 +5,11 @@
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
-
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
  * License for more details.
-
+ *
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
@@ -589,8 +589,8 @@ namespace DotMPTests
             uint threads = 1024;
             int[] int_totals = new int[6];
             long[] long_totals = new long[6];
-            uint[] uint_totals = new uint[5];
-            ulong[] ulong_totals = new ulong[5];
+            uint[] uint_totals = new uint[6];
+            ulong[] ulong_totals = new ulong[6];
 
             uint_totals[1] = 1024;
             ulong_totals[1] = 1024;
@@ -704,6 +704,9 @@ namespace DotMPTests
             long_totals[4].Should().Be((long)res);
             ulong_totals[4].Should().Be((ulong)res);
 
+            uint_totals[5] = threads * 2 + 1;
+            ulong_totals[5] = threads * 2 + 3;
+
             //sub
             DotMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
@@ -711,10 +714,16 @@ namespace DotMPTests
                 DotMP.Atomic.Sub(ref int_totals[5], 2);
                 DotMP.Parallel.Barrier();
                 DotMP.Atomic.Sub(ref long_totals[5], 2);
+                DotMP.Parallel.Barrier();
+                DotMP.Atomic.Sub(ref uint_totals[5], 2);
+                DotMP.Parallel.Barrier();
+                DotMP.Atomic.Sub(ref ulong_totals[5], 2);
             });
 
             int_totals[5].Should().Be((int)-threads * 2);
             long_totals[5].Should().Be((long)-threads * 2);
+            uint_totals[5].Should().Be(1);
+            ulong_totals[5].Should().Be(3);
         }
 
         /// <summary>

--- a/DotMP/Atomic.cs
+++ b/DotMP/Atomic.cs
@@ -5,15 +5,16 @@
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
-
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
  * License for more details.
-
+ *
  * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace DotMP
@@ -102,6 +103,18 @@ namespace DotMP
         public static uint Add(ref uint target, uint value)
         {
             return Interlocked.Add(ref target, value);
+        }
+
+        /// <summary>
+        /// Subtracts two 32-bit unsigned integers and replaces the first integer with the difference, as an atomic operation.
+        /// </summary>
+        /// <param name="target">The destination integer to be replaced.</param>
+        /// <param name="value">The value to subtract from the destination integer.</param>
+        /// <returns>The new value stored as a result of the operation.</returns>
+        public static uint Sub(ref uint target, uint value)
+        {
+            int neg = -(int)value;
+            return Interlocked.Add(ref target, Unsafe.As<int, uint>(ref neg));
         }
 
         /// <summary>
@@ -223,6 +236,18 @@ namespace DotMP
         public static ulong Add(ref ulong target, ulong value)
         {
             return Interlocked.Add(ref target, value);
+        }
+
+        /// <summary>
+        /// Subtracts two 64-bit unsigned integers and replaces the first integer with the difference, as an atomic operation.
+        /// </summary>
+        /// <param name="target">The destination integer to be replaced.</param>
+        /// <param name="value">The value to subtract from the destination integer.</param>
+        /// <returns>The new value stored as a result of the operation.</returns>
+        public static ulong Sub(ref ulong target, ulong value)
+        {
+            long neg = -(long)value;
+            return Interlocked.Add(ref target, Unsafe.As<long, ulong>(ref neg));
         }
 
         /// <summary>

--- a/DotMP/DotMP.csproj
+++ b/DotMP/DotMP.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>DotMP</RootNamespace>
     <PackageId>DotMP</PackageId>
-    <Version>1.6.0-pre1</Version>
+    <Version>1.6.0-pre2</Version>
     <Authors>Phillip Allen Lane,et al.</Authors>
     <PackageDescription>A library for fork-join parallelism in .NET, with an OpenMP-like API.</PackageDescription>
     <RepositoryUrl>https://github.com/computablee/DotMP</RepositoryUrl>
@@ -13,7 +13,7 @@
     <PackageReadmeFile>ProcessedREADME.md</PackageReadmeFile>
     <PackageTags>hpc,parallel,openmp,parallelization,high performance computing,threading</PackageTags>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
-    <PackageReleaseNotes>Add IScheduler interface for user-defined schedulers and work-stealing scheduler. Performance improvements and bug fixes.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add IScheduler interface for user-defined schedulers and work-stealing scheduler. Better atomics support. Performance improvements and bug fixes.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
<!--

Thanks for opening a pull request!

If this is your first time contributing, please read the contributor guidelines.
There are several types of low-quality PRs that are grounds for immediate rejection!
Please make sure you are not falling victim to that.
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md

-->

# Which issue are you addressing?

Closes #117

## How have you addressed the issue?

Implemented `uint Sub(ref uint, uint)` and `ulong Sub(ref ulong, ulong)` for atomic subtraction.

## How have you tested your patch?

Modified `Atomic_works` to test new overloads. Tests pass.