### PR TITLE
Add error checking to ForCollapse

### DIFF
--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1452,6 +1452,18 @@ namespace DotMPTests
         }
 
         /// <summary>
+        /// Verifies that for loops which overflow internal indices should throw an exception.
+        /// </summary>
+        [Fact]
+        public void Overflow_for_should_except()
+        {
+            Assert.Throws<DotMP.Exceptions.TooManyIterationsException>(() =>
+            {
+                DotMP.Parallel.ParallelForCollapse((0, 256), (0, 256), (0, 256), (0, 256), (i, j, k, l) => { });
+            });
+        }
+
+        /// <summary>
         /// Verifies that invalid parameters throw exceptions.
         /// </summary>
         [Fact]
@@ -1465,6 +1477,16 @@ namespace DotMPTests
             Assert.Throws<DotMP.Exceptions.InvalidArgumentsException>(() =>
             {
                 DotMP.Parallel.ParallelFor(-1, 10, i => { });
+            });
+
+            Assert.Throws<DotMP.Exceptions.InvalidArgumentsException>(() =>
+            {
+                DotMP.Parallel.ParallelForCollapse((10, 20), (-1, 10), (i, j) => { });
+            });
+
+            Assert.Throws<DotMP.Exceptions.InvalidArgumentsException>(() =>
+            {
+                DotMP.Parallel.ParallelForCollapse((10, 5), (0, 20), (i, j) => { });
             });
 
             Assert.Throws<DotMP.Exceptions.InvalidArgumentsException>(() =>

--- a/DotMP/Chunk.cs
+++ b/DotMP/Chunk.cs
@@ -454,7 +454,6 @@ namespace DotMP
 
         /// <summary>
         /// Executes a chunk using the action selected by ForAction.selector
-        /// TODO: Optimize this whole function.
         /// </summary>
         /// <param name="curr_iter">A reference to the current iteration.</param>
         /// <param name="start">The start of the chunk, inclusive.</param>

--- a/DotMP/Exceptions.cs
+++ b/DotMP/Exceptions.cs
@@ -65,4 +65,16 @@ namespace DotMP.Exceptions
         /// <param name="msg">The message to associate with the exception.</param>
         public InvalidArgumentsException(string msg) : base(msg) { }
     }
+
+    /// <summary>
+    /// Exception thrown if a for loop has too many iterations and would cause the schedulers to fail.
+    /// </summary>
+    public class TooManyIterationsException : Exception
+    {
+        /// <summary>
+        /// Constructor with a message.
+        /// </summary>
+        /// <param name="msg">The message to associate with the exception.</param>
+        public TooManyIterationsException(string msg) : base(msg) { }
+    }
 }

--- a/DotMP/Parallel.cs
+++ b/DotMP/Parallel.cs
@@ -204,6 +204,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception> 
         public static void ForCollapse((int, int) firstRange, (int, int) secondRange, Action<int, int> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange });
@@ -231,6 +232,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Action<int, int, int> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange, thirdRange });
@@ -260,6 +262,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForCollapse((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Action<int, int, int, int> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, new (int, int)[] { firstRange, secondRange, thirdRange, fourthRange });
@@ -287,6 +290,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForCollapse((int, int)[] ranges, Action<int[]> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<object> forAction = new ForAction<object>(action, ranges);
@@ -394,6 +398,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, Operations op, ref T reduce_to, ActionRef2<T> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<T> forAction = new ForAction<T>(action, new (int, int)[] { firstRange, secondRange });
@@ -426,6 +431,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, Operations op, ref T reduce_to, ActionRef3<T> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<T> forAction = new ForAction<T>(action, new (int, int)[] { firstRange, secondRange, thirdRange });
@@ -460,6 +466,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForReductionCollapse<T>((int, int) firstRange, (int, int) secondRange, (int, int) thirdRange, (int, int) fourthRange, Operations op, ref T reduce_to, ActionRef4<T> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<T> forAction = new ForAction<T>(action, new (int, int)[] { firstRange, secondRange, thirdRange, fourthRange });
@@ -492,6 +499,7 @@ namespace DotMP
         /// <exception cref="NotInParallelRegionException">Thrown when not in a parallel region.</exception>
         /// <exception cref="CannotPerformNestedWorksharingException">Thrown when nested inside another worksharing region.</exception>
         /// <exception cref="InvalidArgumentsException">Thrown if any provided arguments are invalid.</exception>
+        /// <exception cref="TooManyIterationsException">Thrown if there are too many iterations to handle.</exception>
         public static void ForReductionCollapse<T>((int, int)[] ranges, Operations op, ref T reduce_to, ActionRefN<T> action, IScheduler schedule = null, uint? chunk_size = null)
         {
             ForAction<T> forAction = new ForAction<T>(action, ranges);


### PR DESCRIPTION
<!--

Thanks for opening a pull request!

If this is your first time contributing, please read the contributor guidelines.
There are several types of low-quality PRs that are grounds for immediate rejection!
Please make sure you are not falling victim to that.
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md

-->

# Which issue are you addressing?

Makes progress towards #115

## How have you addressed the issue?

Overflow checking is now performed within `ForCollapse` loops, throwing a `TooManyIterationsException` if there are more than `int.MaxValue` total iterations to execute. Additionally, proper argument checking is now performed on `ForCollapse` loops.

## How have you tested your patch?

A new test has been added to check for this situation, which passes.