### PR TITLE
Add checks for overflow in schedulers

### DIFF
--- a/DotMP-Tests/ParallelTests.cs
+++ b/DotMP-Tests/ParallelTests.cs
@@ -1610,6 +1610,18 @@ namespace DotMPTests
         }
 
         /// <summary>
+        /// Ensures that overflows in the schedulers properly throw exceptions.
+        /// </summary>
+        [Fact]
+        public void Boundary_parallelfor_should_except()
+        {
+            Assert.Throws<DotMP.Exceptions.InternalSchedulerException>(() =>
+            {
+                DotMP.Parallel.ParallelFor(0, int.MaxValue, i => { });
+            });
+        }
+
+        /// <summary>
         /// A sample workload for DotMP.Parallel.ParallelFor().
         /// </summary>
         /// <param name="inParallel">Whether or not to enable parallelism.</param>

--- a/DotMP/DotMP.csproj
+++ b/DotMP/DotMP.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>DotMP</RootNamespace>
     <PackageId>DotMP</PackageId>
-    <Version>1.6.0-pre2</Version>
+    <Version>1.6.0</Version>
     <Authors>Phillip Allen Lane,et al.</Authors>
     <PackageDescription>A library for fork-join parallelism in .NET, with an OpenMP-like API.</PackageDescription>
     <RepositoryUrl>https://github.com/computablee/DotMP</RepositoryUrl>

--- a/DotMP/Exceptions.cs
+++ b/DotMP/Exceptions.cs
@@ -89,4 +89,16 @@ namespace DotMP.Exceptions
         /// <param name="msg">The message to associate with the exception.</param>
         public ImproperTaskwaitUsageException(string msg) : base(msg) { }
     }
+
+    /// <summary>
+    /// Exception thrown if the internal schedulers encounter an overflow.
+    /// </summary>
+    public class InternalSchedulerException : Exception
+    {
+        /// <summary>
+        /// Constructor with a message.
+        /// </summary>
+        /// <param name="msg">The message to associate with the exception.</param>
+        public InternalSchedulerException(string msg) : base(msg) { }
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ examples-seq:
 	$(DN) build -c $(BUILD) examples/Serial/KNN
 
 tests:
-	$(DN) build -c $(BUILD) DotMP-Tests
+	$(DN) build -c Debug DotMP-Tests
 
 test:
-	$(DN) test -c $(BUILD) -l "console;verbosity=detailed" -p:CollectCoverage=true -p:CoverletOutputFormat=opencover DotMP-Tests
+	$(DN) test -c Debug -l "console;verbosity=detailed" -p:CollectCoverage=true -p:CoverletOutputFormat=opencover DotMP-Tests
 
 build:
 	$(DN) build -c $(BUILD) -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg DotMP
@@ -42,11 +42,7 @@ docs: ProcessedREADME.md
 	doxygen
 
 pack: ProcessedREADME.md build
-	$(DN) pack -c $(BUILD) DotMP
-	cp ./DotMP/bin/Release/net6.0/DotMP.dll ./DotMP/bin/Release/DotMP-NET6.0.dll
-	cp ./DotMP/bin/Release/net7.0/DotMP.dll ./DotMP/bin/Release/DotMP-NET7.0.dll
-	cp ./DotMP/bin/Release/net6.0/DotMP.pdb ./DotMP/bin/Release/DotMP-NET6.0.pdb
-	cp ./DotMP/bin/Release/net7.0/DotMP.pdb ./DotMP/bin/Release/DotMP-NET7.0.pdb
+	$(DN) pack -c $(BUILD) /p:ContinuousIntegrationBuild=true DotMP
 
 clean:
 	rm -f ProcessedREADME.md


### PR DESCRIPTION
<!--

Thanks for opening a pull request!

If this is your first time contributing, please read the contributor guidelines.
There are several types of low-quality PRs that are grounds for immediate rejection!
Please make sure you are not falling victim to that.
https://github.com/computablee/DotMP/blob/main/CONTRIBUTING.md

-->

# Which issue are you addressing?

<!-- EITHER|OR of the two below -->
<!-- Closes #<issue number> -->
<!-- Closes (paste link of issue) -->
Closes #115 

## How have you addressed the issue?

<!-- describe your fix -->
There are now `checked { }` regions around relevant parts of the schedulers, and a try/catch to rethrow an `InternalSchedulerException` if an overflow is detected.

## How have you tested your patch?

<!-- describe your testing -->
`Boundary_parallelfor_should_except` has been added to the tests, and passes.
